### PR TITLE
Use strlen to determine actual append length

### DIFF
--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -2817,13 +2817,23 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                     buffer,          // TargetValuePtr
                     buffer_size,     // BufferLength
                     &ValueLenOrInd); // StrLen_or_IndPtr
-                if (ValueLenOrInd == SQL_NO_TOTAL || ValueLenOrInd > 0) {
-                    std::size_t append_size = col.ctype_ == SQL_C_BINARY ? buffer_size : strlen(buffer);
-                    if (append_size == 0) {
+                if (ValueLenOrInd == SQL_NO_TOTAL || ValueLenOrInd > 0)
+                {
+                    std::size_t append_size =
+                        col.ctype_ == SQL_C_BINARY ? buffer_size : std::strlen(buffer);
+                    // For some driver and database (e.g. FreeTDS + SQL Server),
+                    // it is likely that rc == SQL_SUCCESS_WITH_INFO is always true,
+                    // causing infinite loop, but buffer is filled
+                    // with all zeros. Sometimes buffer may have multiple trailing zeros.
+                    // Here append_size is used to break potential infinite loop and
+                    // determine the number of chars to append in a more robust manner.
+                    if (append_size == 0)
+                    {
                         rc = SQL_SUCCESS;
                         break;
                     }
-                    if (ValueLenOrInd > 0) {
+                    if (ValueLenOrInd > 0)
+                    {
                         append_size = std::min<std::size_t>(ValueLenOrInd, append_size);
                     }
                     out.append(buffer, append_size);

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -2821,18 +2821,17 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                 // In some cases, buffer has multiple trailing zeros which causes early
                 // termination of string. To avoid that, use strlen(buffer) to determine
                 // the actual string length first and append only this length as supposed.
-                std::size_t append_size = col.ctype_ == SQL_C_BINARY ? buffer_size : strlen(buffer);
-                if (append_size == 0) {
-                    break;
-                }
-                if (ValueLenOrInd == SQL_NO_TOTAL)
+                if (ValueLenOrInd == SQL_NO_TOTAL || ValueLenOrInd > 0) {
+                    std::size_t append_size = col.ctype_ == SQL_C_BINARY ? buffer_size : strlen(buffer);
+                    if (append_size == 0) {
+                        rc = SQL_SUCCESS;
+                        break;
+                    }
+                    if (ValueLenOrInd > 0) {
+                        append_size = std::min<std::size_t>(ValueLenOrInd, append_size);
+                    }
                     out.append(buffer, append_size);
-                else if (ValueLenOrInd > 0)
-                    out.append(
-                        buffer,
-                        std::min<std::size_t>(
-                            ValueLenOrInd,
-                            append_size));
+                }
                 else if (ValueLenOrInd == SQL_NULL_DATA)
                     col.cbdata_[rowset_position_] = (SQLINTEGER)SQL_NULL_DATA;
                 // Sequence of successful calls is:

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -2817,10 +2817,6 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                     buffer,          // TargetValuePtr
                     buffer_size,     // BufferLength
                     &ValueLenOrInd); // StrLen_or_IndPtr
-                // For col.ctype_ != SQL_C_BINARY, buffer is assumed to terminate by 0.
-                // In some cases, buffer has multiple trailing zeros which causes early
-                // termination of string. To avoid that, use strlen(buffer) to determine
-                // the actual string length first and append only this length as supposed.
                 if (ValueLenOrInd == SQL_NO_TOTAL || ValueLenOrInd > 0) {
                     std::size_t append_size = col.ctype_ == SQL_C_BINARY ? buffer_size : strlen(buffer);
                     if (append_size == 0) {


### PR DESCRIPTION
This PR is an attempt to address #171 where each buffer in an iteration is likely to be terminated by multiple trailing zeros. `buffer_size - 1` is not safe enough to remove those trailing zeros. In this case, using `strlen()` is most reliable to determine the actual number of chars to append to `out` in case any early-terminating zeros are mixed into the buffer being appended.

This PR solves both string truncation and infinitely looping problems.

The upstream PR https://github.com/nanodbc/nanodbc/pull/176 has been merged.