### PR TITLE
fix string format of unsupported MSSQL datetimeoffset (-155)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# odbc 1.1.6.9000
+
+- fix SQL Server ODBC's unsupported '-155' data type, and its losing
+  sub-second precision on timestamps; this still returns type
+  `DATETIMEOFFSET` as a character, but it preserves sub-seconds and
+  has a numeric timezone offset (#207, @r2evans)
+
 # odbc 1.1.6
 
 ## Features

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -2623,7 +2623,6 @@ private:
                 break;
             case SQL_TIMESTAMP:
             case SQL_TYPE_TIMESTAMP:
-            case SQL_SS_TIMESTAMPOFFSET:
                 col.ctype_ = SQL_C_TIMESTAMP;
                 col.clen_ = sizeof(timestamp);
                 break;
@@ -2640,6 +2639,7 @@ private:
                 break;
             case SQL_WCHAR:
             case SQL_WVARCHAR:
+            case SQL_SS_TIMESTAMPOFFSET:
                 col.ctype_ = SQL_C_WCHAR;
                 col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);
                 if (is_blob)


### PR DESCRIPTION
- fix format of returned object of type `DATETIMEOFFSET` (-155) from
  `"2018-09-12 22:38:56 Pacific Standard Time"` to
  `"2018-09-13 05:41:20.4607764 +00:00"`
- closes #207, "datetimeoffset unsupported" (in modern SQL Server ODBC drivers)

NB: this does not provide native support for -155 data types: I believe that change ultimately needs to be made in nanodbc, though issues seem to be stale (https://github.com/nanodbc/nanodbc/issues/19 and https://github.com/nanodbc/nanodbc/issues/18). This does not change the return value either, it is still `character`. The sole difference is making it a more parse-able format (allowing downstream code to at least choose to parse it while preserving sub-second precision).

My testing included SQL Server and PostgreSQL, not MariaDB. (Not relevant for SQLite, I think.) I tried 4 versions of the SQL Server driver, and 2 versions of the PostgreSQL driver (to ensure no unintended changes, output can be included on request):

- "SQL Server"
- "SQL Server Native Client 11.0"
- "ODBC Driver 13 for SQL Server"
- "ODBC Driver 17 for SQL Server"
- "PostgreSQL ANSI(x64)" and "PostgreSQL Unicode(x64)"

Short version, demonstrating the problem and the fixed `character` string returned (though still not `POSIXt`):

```r
# original
DBI::dbGetQuery(con, "select SYSDATETIMEOFFSET() as a")$a
"2018-09-12 22:38:56 Pacific Standard Time"
# fixed with this PR
"2018-09-13 05:41:20.4607764 +00:00"
```

<details>
<summary>Long Version</summary>

Long version, showing various date/time functions. The whole query:

```r
a <- DBI::dbGetQuery(con, "select 1 as id
  ,sysdatetimeoffset() as sdto
  ,cast(sysdatetimeoffset() as nvarchar(64)) as sdto2
  ,sysdatetime() as sdt
  ,cast(sysdatetime() as nvarchar(64)) as sdt2
  ,CURRENT_TIMESTAMP as ct
  ,SYSUTCDATETIME() as sudt
  ,cast(SYSUTCDATETIME() as nvarchar(64)) as sudt2
  ,GETDATE() as gd
  ,cast(GETDATE() as nvarchar(64)) as gd2
  ,GETUTCDATE() as gud
  ,cast(GETUTCDATE() as nvarchar(64)) as gud2")
```

And the collated results, with `<---` indicating the rows where the format has changed. (These comparisons were not automated, so the actual time-of-day is different between individual connections and queries.)

```
    UNCHANGED                                        CHANGED
"SQL Server"                                                 
    chr "2018-09-13 05:26:58.1048492 +00:00"         chr "2018-09-13 05:23:48.4741124 +00:00"
    chr "2018-09-13 05:26:58.1048492 +00:00"         chr "2018-09-13 05:23:48.4741124 +00:00"
    chr "2018-09-13 05:26:58.1048492"                chr "2018-09-13 05:23:48.4741124"       
    chr "2018-09-13 05:26:58.1048492"                chr "2018-09-13 05:23:48.4741124"       
    POSIXct, format: "2018-09-13 05:26:58"           POSIXct, format: "2018-09-13 05:23:48"  
    chr "2018-09-13 05:26:58.1048492"                chr "2018-09-13 05:23:48.4741124"       
    chr "2018-09-13 05:26:58.1048492"                chr "2018-09-13 05:23:48.4741124"       
    POSIXct, format: "2018-09-13 05:26:58"           POSIXct, format: "2018-09-13 05:23:48"  
    chr "Sep 13 2018  5:26AM"                        chr "Sep 13 2018  5:23AM"               
    POSIXct, format: "2018-09-13 05:26:58"           POSIXct, format: "2018-09-13 05:23:48"  
    chr "Sep 13 2018  5:26AM"                        chr "Sep 13 2018  5:23AM"               
"SQL Server Native Client 11.0"
    chr "2018-09-12 22:38:56 Pacific Standard Time"  chr "2018-09-13 05:41:20.4607764 +00:00" <---
    chr "2018-09-13 05:38:56.6079308 +00:00"         chr "2018-09-13 05:41:20.4607764 +00:00"
    POSIXct, format: "2018-09-13 05:38:56"           POSIXct, format: "2018-09-13 05:41:20"  
    chr "2018-09-13 05:38:56.6079308"                chr "2018-09-13 05:41:20.4607764"       
    POSIXct, format: "2018-09-13 05:38:56"           POSIXct, format: "2018-09-13 05:41:20"  
    POSIXct, format: "2018-09-13 05:38:56"           POSIXct, format: "2018-09-13 05:41:20"  
    chr "2018-09-13 05:38:56.6079308"                chr "2018-09-13 05:41:20.4607764"       
    POSIXct, format: "2018-09-13 05:38:56"           POSIXct, format: "2018-09-13 05:41:20"  
    chr "Sep 13 2018  5:38AM"                        chr "Sep 13 2018  5:41AM"               
    POSIXct, format: "2018-09-13 05:38:56"           POSIXct, format: "2018-09-13 05:41:20"  
    chr "Sep 13 2018  5:38AM"                        chr "Sep 13 2018  5:41AM"               
"ODBC Driver 13 for SQL Server"
    chr "2018-09-12 22:39:41 Pacific Standard Time"  chr "2018-09-13 05:40:45.2633035 +00:00" <---
    chr "2018-09-13 05:39:41.8131106 +00:00"         chr "2018-09-13 05:40:45.2633035 +00:00"
    POSIXct, format: "2018-09-13 05:39:41"           POSIXct, format: "2018-09-13 05:40:45"  
    chr "2018-09-13 05:39:41.8131106"                chr "2018-09-13 05:40:45.2633035"       
    POSIXct, format: "2018-09-13 05:39:41"           POSIXct, format: "2018-09-13 05:40:45"  
    POSIXct, format: "2018-09-13 05:39:41"           POSIXct, format: "2018-09-13 05:40:45"  
    chr "2018-09-13 05:39:41.8131106"                chr "2018-09-13 05:40:45.2633035"       
    POSIXct, format: "2018-09-13 05:39:41"           POSIXct, format: "2018-09-13 05:40:45"  
    chr "Sep 13 2018  5:39AM"                        chr "Sep 13 2018  5:40AM"               
    POSIXct, format: "2018-09-13 05:39:41"           POSIXct, format: "2018-09-13 05:40:45"  
    chr "Sep 13 2018  5:39AM"                        chr "Sep 13 2018  5:40AM"               
"ODBC Driver 17 for SQL Server"
    chr "2018-09-12 22:26:14 Pacific Standard Time"  chr "2018-09-13 05:25:01.9728530 +00:00" <---
    chr "2018-09-13 05:26:14.8681213 +00:00"         chr "2018-09-13 05:25:01.9728530 +00:00"
    POSIXct, format: "2018-09-13 05:26:14"           POSIXct, format: "2018-09-13 05:25:01"  
    chr "2018-09-13 05:26:14.8681213"                chr "2018-09-13 05:25:01.9728530"       
    POSIXct, format: "2018-09-13 05:26:14"           POSIXct, format: "2018-09-13 05:25:01"  
    POSIXct, format: "2018-09-13 05:26:14"           POSIXct, format: "2018-09-13 05:25:01"  
    chr "2018-09-13 05:26:14.8681213"                chr "2018-09-13 05:25:01.9728530"       
    POSIXct, format: "2018-09-13 05:26:14"           POSIXct, format: "2018-09-13 05:25:01"  
    chr "Sep 13 2018  5:26AM"                        chr "Sep 13 2018  5:25AM"               
    POSIXct, format: "2018-09-13 05:26:14"           POSIXct, format: "2018-09-13 05:25:01"  
    chr "Sep 13 2018  5:26AM"                        chr "Sep 13 2018  5:25AM"                              
```
</details>