### PR TITLE
Allow drivers to be filtered from odbcListDrivers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Features
 
+* `odbcListDrivers()` gains a `keep` and `filter` argument and global options
+  `odbc.drivers_keep`, `odbc.drivers_filter` to keep and filter the drivers
+  returned. This is useful if system administrators want to reduce the number
+  of drivers shown to users. (@blairj09, #274)
+
 ## Bugfixes
 
 * Fixed an issue where `DBI::dbListFields()` could fail when used with a

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -314,7 +314,8 @@ setMethod(
 #'
 #' @return A data frame with three columns.
 #' If a given driver does not have any attributes the last two columns will be
-#' `NA`.
+#' `NA`. Drivers can be excluded from being returned by setting the
+#' \code{odbc.drivers.filter} option.
 #' \describe{
 #'   \item{name}{Name of the driver}
 #'   \item{attribute}{Driver attribute name}
@@ -325,6 +326,7 @@ odbcListDrivers <- function() {
   res <- list_drivers_()
   if (nrow(res) > 0) {
     res[res == ""] <- NA_character_
+    res <- res[!res[["name"]] %in% getOption("odbc.drivers.filter"),]
   }
   res
 }

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -312,6 +312,10 @@ setMethod(
 
 #' List Available ODBC Drivers
 #'
+#' @param keep A character vector of driver names to keep in the results, if
+#'   `NULL` (the default) will keep all drivers.
+#' @param filter A character vector of driver names to filter from the results, if
+#'   `NULL` (the default) will not filter any drivers.
 #' @return A data frame with three columns.
 #' If a given driver does not have any attributes the last two columns will be
 #' `NA`. Drivers can be excluded from being returned by setting the
@@ -322,12 +326,21 @@ setMethod(
 #'   \item{value}{Driver attribute value}
 #' }
 #' @export
-odbcListDrivers <- function() {
+odbcListDrivers <- function(keep = getOption("odbc.drivers_keep"), filter = getOption("odbc.drivers_filter")) {
   res <- list_drivers_()
+
   if (nrow(res) > 0) {
     res[res == ""] <- NA_character_
-    res <- res[!res[["name"]] %in% getOption("odbc.drivers.filter"),]
+
+    if (!is.null(keep)) {
+      res <- res[res[["name"]] %in% keep, ]
+    }
+
+    if (!is.null(filter)) {
+      res <- res[!res[["name"]] %in% filter, ]
+    }
   }
+
   res
 }
 

--- a/man/OdbcConnection.Rd
+++ b/man/OdbcConnection.Rd
@@ -48,8 +48,7 @@
 
 \S4method{dbGetInfo}{OdbcConnection}(dbObj, ...)
 
-\S4method{dbGetQuery}{OdbcConnection,character}(conn, statement, n = -1,
-  ...)
+\S4method{dbGetQuery}{OdbcConnection,character}(conn, statement, n = -1, ...)
 
 \S4method{dbBegin}{OdbcConnection}(conn, ...)
 
@@ -77,7 +76,7 @@ or a \linkS4class{DBIResult}}
 
 \item{obj}{An R object whose SQL type we want to determine.}
 
-\item{x}{A character vector, \link{SQL} or \link{Id} object to quote as identifier.}
+\item{x}{A character vector, \link[DBI]{SQL} or \link[DBI]{Id} object to quote as identifier.}
 
 \item{name}{A character string specifying a DBMS table name.}
 

--- a/man/odbcListDrivers.Rd
+++ b/man/odbcListDrivers.Rd
@@ -4,7 +4,17 @@
 \alias{odbcListDrivers}
 \title{List Available ODBC Drivers}
 \usage{
-odbcListDrivers()
+odbcListDrivers(
+  keep = getOption("odbc.drivers_keep"),
+  filter = getOption("odbc.drivers_filter")
+)
+}
+\arguments{
+\item{keep}{A character vector of driver names to keep in the results, if
+\code{NULL} (the default) will keep all drivers.}
+
+\item{filter}{A character vector of driver names to filter from the results, if
+\code{NULL} (the default) will not filter any drivers.}
 }
 \value{
 A data frame with three columns.

--- a/man/odbcListDrivers.Rd
+++ b/man/odbcListDrivers.Rd
@@ -9,7 +9,8 @@ odbcListDrivers()
 \value{
 A data frame with three columns.
 If a given driver does not have any attributes the last two columns will be
-\code{NA}.
+\code{NA}. Drivers can be excluded from being returned by setting the
+\code{odbc.drivers.filter} option.
 \describe{
 \item{name}{Name of the driver}
 \item{attribute}{Driver attribute name}

--- a/tests/testthat/test-drivers.R
+++ b/tests/testthat/test-drivers.R
@@ -7,14 +7,15 @@ test_that("odbcListDrivers() returns available drivers", {
   expect_true(nrow(res) >= 1)
 })
 
-test_that("odbcListDrivers() honors odbc.drivers.filter option", {
+test_that("odbcListDrivers() keep and filter work", {
   skip_on_cran()
-  existing_filter <- options("odbc.drivers.filter")
-  options(odbc.drivers.filter = odbcListDrivers()[["name"]])
-  res <- odbcListDrivers()
-  options(odbc.drivers.filter = existing_filter)
+
+  current_drivers <- odbcListDrivers()[["name"]]
+  res <- odbcListDrivers(filter = current_drivers)
   expect_true(nrow(res) == 0)
 
+  res <- odbcListDrivers(keep = current_drivers[[1]])
+  expect_true(nrow(res) == 1)
 })
 
 test_that("odbcListDataSources() returns available data sources", {

--- a/tests/testthat/test-drivers.R
+++ b/tests/testthat/test-drivers.R
@@ -7,6 +7,16 @@ test_that("odbcListDrivers() returns available drivers", {
   expect_true(nrow(res) >= 1)
 })
 
+test_that("odbcListDrivers() honors odbc.drivers.filter option", {
+  skip_on_cran()
+  existing_filter <- options("odbc.drivers.filter")
+  options(odbc.drivers.filter = odbcListDrivers()[["name"]])
+  res <- odbcListDrivers()
+  options(odbc.drivers.filter = existing_filter)
+  expect_true(nrow(res) == 0)
+
+})
+
 test_that("odbcListDataSources() returns available data sources", {
   skip_on_cran()
   res <- odbcListDataSources()


### PR DESCRIPTION
This option allows users or system administrators to set the `odbc.drivers.filter` option in order to exclude some/all drivers from being returned by `odbcListDrivers()`. This can be helpful for system administrators who don't want users seeing all the available drivers and/or who don't want the IDE to provide automatic references to installed drivers in the connections pane.

Example:
``` r
odbc::odbcListDrivers()
#>          name attribute
#> 1      Athena    Driver
#> 2    BigQuery    Driver
#> 3   Cassandra    Driver
#> 4        Hive    Driver
#> 5      Impala    Driver
#> 6     MongoDB    Driver
#> 7       MySQL    Driver
#> 8     Netezza    Driver
#> 9      Oracle    Driver
#> 10 PostgreSQL    Driver
#> 11   Redshift    Driver
#> 12 Salesforce    Driver
#> 13  SQLServer    Driver
#> 14   Teradata    Driver
#>                                                                  value
#> 1            /opt/rstudio-drivers/athena/bin/lib/libathenaodbc_sb64.so
#> 2  /opt/rstudio-drivers/bigquery/bin/lib/libgooglebigqueryodbc_sb64.so
#> 3      /opt/rstudio-drivers/cassandra/bin/lib/libcassandraodbc_sb64.so
#> 4                /opt/rstudio-drivers/hive/bin/lib/libhiveodbc_sb64.so
#> 5            /opt/rstudio-drivers/impala/bin/lib/libimpalaodbc_sb64.so
#> 6          /opt/rstudio-drivers/mongodb/bin/lib/libmongodbodbc_sb64.so
#> 7              /opt/rstudio-drivers/mysql/bin/lib/libmysqlodbc_sb64.so
#> 8          /opt/rstudio-drivers/netezza/bin/lib/libnetezzaodbc_sb64.so
#> 9            /opt/rstudio-drivers/oracle/bin/lib/liboracleodbc_sb64.so
#> 10   /opt/rstudio-drivers/postgresql/bin/lib/libpostgresqlodbc_sb64.so
#> 11 /opt/rstudio-drivers/redshift/bin/lib/libamazonredshiftodbc_sb64.so
#> 12   /opt/rstudio-drivers/salesforce/bin/lib/libsalesforceodbc_sb64.so
#> 13     /opt/rstudio-drivers/sqlserver/bin/lib/libsqlserverodbc_sb64.so
#> 14             /opt/rstudio-drivers/teradata/bin/lib/tdataodbc_sb64.so
options(odbc.drivers.filter = odbc::odbcListDrivers()[["name"]])
odbc::odbcListDrivers()
#> [1] name      attribute value    
#> <0 rows> (or 0-length row.names)
```

Before adding the `odbc.drivers.filter` option:
![image](https://user-images.githubusercontent.com/10444878/56533565-1f93a880-6515-11e9-82b5-e7203a4dc135.png)

After running `options(odbc.drivers.filter = odbc::odbcListDrivers()[["name"]])`:
![image](https://user-images.githubusercontent.com/10444878/56533583-2f12f180-6515-11e9-9c60-fa4eb486ee3c.png)
