### PR TITLE
WIP: Use const& for database errors

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -66,7 +66,7 @@ connection_ptr odbc_connect(
 std::string get_info_or_empty(connection_ptr const& p, short type) {
   try {
     return (*p)->connection()->get_info<std::string>(type);
-  } catch (nanodbc::database_error c) {
+  } catch (const nanodbc::database_error& c) {
     return "";
   }
 }

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -42,7 +42,7 @@ odbc_connection::odbc_connection(
 
   try {
     c_ = std::make_shared<nanodbc::connection>(connection_string, timeout);
-  } catch (nanodbc::database_error e) {
+  } catch (const nanodbc::database_error& e) {
     throw Rcpp::exception(e.what(), FALSE);
   }
 }
@@ -80,7 +80,7 @@ bool odbc_connection::is_current_result(odbc_result* result) const {
 bool odbc_connection::supports_transactions() const {
   try {
     return c_->get_info<unsigned short>(SQL_TXN_CAPABLE) != SQL_TC_NONE;
-  } catch (nanodbc::database_error e) {
+  } catch (const nanodbc::database_error& e) {
     return false;
   }
 }

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -18,7 +18,7 @@ inline void signal_unknown_field_type(short type, const std::string& name) {
 
 class odbc_error : public Rcpp::exception {
 public:
-  odbc_error(const nanodbc::database_error e, const std::string& sql)
+  odbc_error(const nanodbc::database_error& e, const std::string& sql)
       : Rcpp::exception("", false) {
     message = std::string(e.what()) + "\n<SQL> '" + sql + "'";
   }


### PR DESCRIPTION
to avoid copying of exception objects.