### PR TITLE
new param timezone_out to control the timezone returned to R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * The RStudio Connections Pane now shows the DSN, when available (#304, @davidchall).
 
 * `dbConnect()` now has a new param `timezone_out` which is useful if the user wants 
-  the datetime values be marked as a specific timezone instead of UTC (@shrektan, #294).
+  the datetime values be marked with a specific timezone instead of UTC (@shrektan, #294).
 
 ## Bugfixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * The RStudio Connections Pane now shows the DSN, when available (#304, @davidchall).
 
+* `dbConnect()` now has a new param `timezone_out` which is useful if the user wants 
+  the datetime values be marked as a specific timezone instead of UTC (@shrektan, #294).
+
 ## Bugfixes
 
 * Fixed an issue where `DBI::dbListFields()` could fail when used with a

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 * Fix SQL Server ODBC's unsupported '-155' data type, and its losing
   sub-second precision on timestamps; this still returns type
   `DATETIMEOFFSET` as a character, but it preserves sub-seconds and
- has a numeric timezone offset (@r2evans, #207).
+  has a numeric timezone offset (@r2evans, #207).
   
 * Fix an issue that the date value fetched from the database may be one
   day before its real value (@shrektan, #295).

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -14,6 +14,7 @@ OdbcConnection <- function(
   dsn = NULL,
   ...,
   timezone = "UTC",
+  timezone_out = "UTC",
   encoding = "",
   bigint = c("integer64", "integer", "numeric", "character"),
   timeout = Inf,
@@ -36,7 +37,7 @@ OdbcConnection <- function(
     timeout <- 0
   }
 
-  ptr <- odbc_connect(connection_string, timezone = timezone, encoding = encoding, bigint = bigint, timeout = timeout)
+  ptr <- odbc_connect(connection_string, timezone = timezone, timezone_out = timezone_out, encoding = encoding, bigint = bigint, timeout = timeout)
   quote <- connection_quote(ptr)
 
   info <- connection_info(ptr)

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -45,6 +45,8 @@ setMethod(
 #' timezone that is _not_ 'UTC'. If the database is in your local timezone set
 #' to `Sys.timezone()`. See [OlsonNames()] for a complete list of available
 #' timezones on your system.
+#' @param timezone_out The time zone returned to R. Useful if you want the
+#' timezone returned to R is _not_ 'UTC'.
 #' @param encoding The text encoding used on the Database. If the database is
 #' not using UTF-8 you will need to set the encoding to get accurate re-encoding.
 #' See [iconvlist()] for a complete list of available encodings on your system.
@@ -83,6 +85,7 @@ setMethod(
     dsn = NULL,
     ...,
     timezone = "UTC",
+    timezone_out = "UTC",
     encoding = "",
     bigint = c("integer64", "integer", "numeric", "character"),
     timeout = 10,
@@ -98,6 +101,7 @@ setMethod(
       dsn = dsn,
       ...,
       timezone = timezone,
+      timezone_out = timezone_out,
       encoding = encoding,
       bigint = bigint,
       timeout = timeout,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,8 +9,8 @@ list_data_sources_ <- function() {
     .Call(`_odbc_list_data_sources_`)
 }
 
-odbc_connect <- function(connection_string, timezone = "", encoding = "", bigint = 0L, timeout = 0L) {
-    .Call(`_odbc_odbc_connect`, connection_string, timezone, encoding, bigint, timeout)
+odbc_connect <- function(connection_string, timezone = "", timezone_out = "", encoding = "", bigint = 0L, timeout = 0L) {
+    .Call(`_odbc_odbc_connect`, connection_string, timezone, timezone_out, encoding, bigint, timeout)
 }
 
 connection_info <- function(p) {

--- a/man/dbConnect-OdbcDriver-method.Rd
+++ b/man/dbConnect-OdbcDriver-method.Rd
@@ -7,10 +7,11 @@
 \title{Connect to a ODBC compatible database}
 \usage{
 \S4method{dbConnect}{OdbcDriver}(drv, dsn = NULL, ...,
-  timezone = "UTC", encoding = "", bigint = c("integer64", "integer",
-  "numeric", "character"), timeout = 10, driver = NULL,
-  server = NULL, database = NULL, uid = NULL, pwd = NULL,
-  dbms.name = NULL, .connection_string = NULL)
+  timezone = "UTC", timezone_out = "UTC", encoding = "",
+  bigint = c("integer64", "integer", "numeric", "character"),
+  timeout = 10, driver = NULL, server = NULL, database = NULL,
+  uid = NULL, pwd = NULL, dbms.name = NULL,
+  .connection_string = NULL)
 }
 \arguments{
 \item{drv}{an object that inherits from \linkS4class{DBIDriver},
@@ -26,6 +27,9 @@ arguments to form the final connection string.}
 timezone that is \emph{not} 'UTC'. If the database is in your local timezone set
 to \code{Sys.timezone()}. See \code{\link[=OlsonNames]{OlsonNames()}} for a complete list of available
 timezones on your system.}
+
+\item{timezone_out}{The time zone returned to R. Useful if you want the
+timezone returned to R is \emph{not} 'UTC'.}
 
 \item{encoding}{The text encoding used on the Database. If the database is
 not using UTF-8 you will need to set the encoding to get accurate re-encoding.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -27,17 +27,18 @@ BEGIN_RCPP
 END_RCPP
 }
 // odbc_connect
-connection_ptr odbc_connect(std::string const& connection_string, std::string const& timezone, std::string const& encoding, int bigint, long timeout);
-RcppExport SEXP _odbc_odbc_connect(SEXP connection_stringSEXP, SEXP timezoneSEXP, SEXP encodingSEXP, SEXP bigintSEXP, SEXP timeoutSEXP) {
+connection_ptr odbc_connect(std::string const& connection_string, std::string const& timezone, std::string const& timezone_out, std::string const& encoding, int bigint, long timeout);
+RcppExport SEXP _odbc_odbc_connect(SEXP connection_stringSEXP, SEXP timezoneSEXP, SEXP timezone_outSEXP, SEXP encodingSEXP, SEXP bigintSEXP, SEXP timeoutSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string const& >::type connection_string(connection_stringSEXP);
     Rcpp::traits::input_parameter< std::string const& >::type timezone(timezoneSEXP);
+    Rcpp::traits::input_parameter< std::string const& >::type timezone_out(timezone_outSEXP);
     Rcpp::traits::input_parameter< std::string const& >::type encoding(encodingSEXP);
     Rcpp::traits::input_parameter< int >::type bigint(bigintSEXP);
     Rcpp::traits::input_parameter< long >::type timeout(timeoutSEXP);
-    rcpp_result_gen = Rcpp::wrap(odbc_connect(connection_string, timezone, encoding, bigint, timeout));
+    rcpp_result_gen = Rcpp::wrap(odbc_connect(connection_string, timezone, timezone_out, encoding, bigint, timeout));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -310,7 +311,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_odbc_list_drivers_", (DL_FUNC) &_odbc_list_drivers_, 0},
     {"_odbc_list_data_sources_", (DL_FUNC) &_odbc_list_data_sources_, 0},
-    {"_odbc_odbc_connect", (DL_FUNC) &_odbc_odbc_connect, 5},
+    {"_odbc_odbc_connect", (DL_FUNC) &_odbc_odbc_connect, 6},
     {"_odbc_connection_info", (DL_FUNC) &_odbc_connection_info, 1},
     {"_odbc_connection_quote", (DL_FUNC) &_odbc_connection_quote, 1},
     {"_odbc_connection_release", (DL_FUNC) &_odbc_connection_release, 1},

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -49,6 +49,7 @@ Rcpp::DataFrame list_data_sources_() {
 connection_ptr odbc_connect(
     std::string const& connection_string,
     std::string const& timezone = "",
+    std::string const& timezone_out = "",
     std::string const& encoding = "",
     int bigint = 0,
     long timeout = 0) {
@@ -56,6 +57,7 @@ connection_ptr odbc_connect(
       new std::shared_ptr<odbc_connection>(new odbc_connection(
           connection_string,
           timezone,
+          timezone_out,
           encoding,
           static_cast<bigint_map_t>(bigint),
           timeout)));

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -34,6 +34,8 @@ odbc_connection::odbc_connection(
     Rcpp::stop("Error loading time zone (%s)", timezone);
   }
 
+  // timezone_out_ will not be used. This line is just to ensure
+  // the provided value is valid.
   if (!cctz::load_time_zone(timezone_out, &timezone_out_)) {
     Rcpp::stop("Error loading timezone_out (%s)", timezone_out);
   }

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -35,7 +35,7 @@ odbc_connection::odbc_connection(
   }
 
   if (!cctz::load_time_zone(timezone_out, &timezone_out_)) {
-    Rcpp::stop("Error loading time zone (%s)", timezone_out);
+    Rcpp::stop("Error loading timezone_out (%s)", timezone_out);
   }
 
   try {
@@ -84,7 +84,6 @@ bool odbc_connection::supports_transactions() const {
 }
 
 cctz::time_zone odbc_connection::timezone() const { return timezone_; }
-cctz::time_zone odbc_connection::timezone_out() const { return timezone_out_; }
 std::string odbc_connection::timezone_out_str() const { return timezone_out_str_; }
 std::string odbc_connection::encoding() const { return encoding_; }
 

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -86,7 +86,9 @@ bool odbc_connection::supports_transactions() const {
 }
 
 cctz::time_zone odbc_connection::timezone() const { return timezone_; }
-std::string odbc_connection::timezone_out_str() const { return timezone_out_str_; }
+std::string odbc_connection::timezone_out_str() const {
+  return timezone_out_str_;
+}
 std::string odbc_connection::encoding() const { return encoding_; }
 
 bigint_map_t odbc_connection::get_bigint_mapping() const {

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -21,15 +21,21 @@ void odbc_connection::set_current_result(odbc_result* r) {
 odbc_connection::odbc_connection(
     std::string connection_string,
     std::string timezone,
+    std::string timezone_out,
     std::string encoding,
     bigint_map_t bigint_mapping,
     long timeout)
     : current_result_(nullptr),
+      timezone_out_str_(timezone_out),
       encoding_(encoding),
       bigint_mapping_(bigint_mapping) {
 
   if (!cctz::load_time_zone(timezone, &timezone_)) {
     Rcpp::stop("Error loading time zone (%s)", timezone);
+  }
+
+  if (!cctz::load_time_zone(timezone_out, &timezone_out_)) {
+    Rcpp::stop("Error loading time zone (%s)", timezone_out);
   }
 
   try {
@@ -78,6 +84,8 @@ bool odbc_connection::supports_transactions() const {
 }
 
 cctz::time_zone odbc_connection::timezone() const { return timezone_; }
+cctz::time_zone odbc_connection::timezone_out() const { return timezone_out_; }
+std::string odbc_connection::timezone_out_str() const { return timezone_out_str_; }
 std::string odbc_connection::encoding() const { return encoding_; }
 
 bigint_map_t odbc_connection::get_bigint_mapping() const {

--- a/src/odbc_connection.h
+++ b/src/odbc_connection.h
@@ -21,6 +21,7 @@ public:
   odbc_connection(
       std::string connection_string,
       std::string timezone = "UTC",
+      std::string timezone_out = "UTC",
       std::string encoding = "",
       bigint_map_t bigint_mapping = i64_to_integer64,
       long timeout = 0);
@@ -37,6 +38,8 @@ public:
   void set_current_result(odbc_result* r);
 
   cctz::time_zone timezone() const;
+  cctz::time_zone timezone_out() const;
+  std::string timezone_out_str() const;
   std::string encoding() const;
 
   bigint_map_t get_bigint_mapping() const;
@@ -46,6 +49,8 @@ private:
   std::unique_ptr<nanodbc::transaction> t_;
   odbc_result* current_result_;
   cctz::time_zone timezone_;
+  cctz::time_zone timezone_out_;
+  std::string timezone_out_str_;
   std::string encoding_;
   bigint_map_t bigint_mapping_;
 };

--- a/src/odbc_connection.h
+++ b/src/odbc_connection.h
@@ -38,7 +38,6 @@ public:
   void set_current_result(odbc_result* r);
 
   cctz::time_zone timezone() const;
-  cctz::time_zone timezone_out() const;
   std::string timezone_out_str() const;
   std::string encoding() const;
 

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -416,7 +416,7 @@ double odbc_result::as_double(nanodbc::timestamp const& ts) {
 
 double odbc_result::as_double(nanodbc::date const& dt) {
   using namespace cctz;
-  auto sec = convert(civil_day(dt.year, dt.month, dt.day), c_->timezone());
+  auto sec = convert(civil_day(dt.year, dt.month, dt.day), c_->timezone_out());
   return sec.time_since_epoch().count();
 }
 
@@ -484,7 +484,7 @@ void odbc_result::add_classes(
       break;
     case datetime_t:
       x.attr("class") = Rcpp::CharacterVector::create("POSIXct", "POSIXt");
-      x.attr("tzone") = Rcpp::CharacterVector::create("UTC");
+      x.attr("tzone") = Rcpp::CharacterVector::create(c_->timezone_out_str());
       break;
     case odbc::time_t:
       x.attr("class") = Rcpp::CharacterVector::create("hms", "difftime");

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -416,7 +416,7 @@ double odbc_result::as_double(nanodbc::timestamp const& ts) {
 
 double odbc_result::as_double(nanodbc::date const& dt) {
   using namespace cctz;
-  auto sec = convert(civil_day(dt.year, dt.month, dt.day), c_->timezone_out());
+  auto sec = convert(civil_day(dt.year, dt.month, dt.day), c_->timezone());
   return sec.time_since_epoch().count();
 }
 

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -416,7 +416,8 @@ double odbc_result::as_double(nanodbc::timestamp const& ts) {
 
 double odbc_result::as_double(nanodbc::date const& dt) {
   using namespace cctz;
-  auto sec = convert(civil_day(dt.year, dt.month, dt.day), cctz::utc_time_zone());
+  auto sec =
+    convert(civil_day(dt.year, dt.month, dt.day), cctz::utc_time_zone());
   return sec.time_since_epoch().count();
 }
 


### PR DESCRIPTION
Closes #275 

This PR allows user to define a new param `timezone_out` so that the timezone of the returned object can be local timezone or whatever other than UTC. 

I believe it is very convinient for many users because usually the timezones on the local machine and the server are the same. By forcing the timezone to be UTC leads to sort-of confusing for users, especially those who are not familiar with timezone things.

## An Example

Note this result now displays the same as what's in SQL. But without this functionality, the user will get "2018-12-31 20:00:00 UTC" and have to convert it to "Asia/Shanghai" later by themselves, which is verbose and inconvinient.

``` r
con <- DBI::dbConnect(
  odbc::odbc(),
  server = '#hide#', database = '#hide#', uid = '#hide#', pwd = '#hide#',
  encoding = 'GB2312', driver = 'SQL Server', port = #hide#,
  timezone = 'Asia/Shanghai', timezone_out = 'Asia/Shanghai'
)
out <- DBI::dbGetQuery(con, "select cast('2019-01-01 04:00:00' as datetime) as datetime")
str(out)
#> 'data.frame':    1 obs. of  1 variable:
#>  $ datetime: POSIXct, format: "2019-01-01 04:00:00"
attributes(out$datetime)  
#> $class
#> [1] "POSIXct" "POSIXt" 
#> 
#> $tzone
#> [1] "Asia/Shanghai"
DBI::dbDisconnect(con)
```

<sup>Created on 2019-08-26 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
