### PR TITLE
odbc_result::as_double(date) should use UTC timezone

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
   sub-second precision on timestamps; this still returns type
   `DATETIMEOFFSET` as a character, but it preserves sub-seconds and
   has a numeric timezone offset (#207, @r2evans)
+  
+* Fix an issue that the date value fetched from the database may be one
+  day before its real value (@shrektan, #295).
 
 # odbc 1.1.6
 

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -416,7 +416,7 @@ double odbc_result::as_double(nanodbc::timestamp const& ts) {
 
 double odbc_result::as_double(nanodbc::date const& dt) {
   using namespace cctz;
-  auto sec = convert(civil_day(dt.year, dt.month, dt.day), c_->timezone());
+  auto sec = convert(civil_day(dt.year, dt.month, dt.day), cctz::utc_time_zone());
   return sec.time_since_epoch().count();
 }
 


### PR DESCRIPTION
Closes #293

It's because the user timezone info on `date` is meaningless. Converting to the user timezone then extracting the date part will leading to one-day leap if the timezone is UTC+n, like Asia/Shanghai, or "Europe/Berlin". 

This PR will address this issue.

### Example

(Before this PR, the result is "2018-12-31")

``` r
con <- DBI::dbConnect(
  odbc::odbc(),
  server = '#hide#', database = '#hide#', uid = '#hide#', pwd = '#hide#',
  encoding = 'GB2312', driver = '{SQL Server Native Client 11.0}', port = 1433,
  timezone = 'Asia/Shanghai'
)
out <- DBI::dbGetQuery(con, "select cast('2019-01-01' as date) as aaa")
str(out)
#> 'data.frame':    1 obs. of  1 variable:
#>  $ aaa: Date, format: "2019-01-01"
```

<sup>Created on 2019-08-26 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

