### PR TITLE
Show DSN in RStudio Connections Pane (when available)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+* The RStudio Connections Pane now shows the DSN, when available (#304, @davidchall)
+
 ## Bugfixes
 
 * Fixed an issue where `DBI::dbListFields()` could fail when used with a

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -148,6 +148,12 @@ computeHostName <- function(connection) {
 
 computeDisplayName <- function(connection) {
 
+  # use DSN if present
+  dsn <- connection@info$sourcename
+  if (!is.null(dsn) & dsn != "") {
+    return(dsn)
+  }
+
   # use the database name as the display name
   display_name <- connection@info$dbname
   server_name <- connection@info$servername


### PR DESCRIPTION
The RStudio Connections Pane uses a `displayName` to summarize each connection.

Currently, the odbc package shows something like `dbname - username@hostname via TCP/IP`, which can get quite long (spilling over multiple lines).

When available, the Data Source Name provides a (probably) shorter string that still uniquely identifies the database connection. It's also highly likely that the DSN is easier for the user to interpret, because it was expressly designed for this purpose.