### PR TITLE
Use setDBIMethod()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ LazyData: true
 ByteCompile: true
 Depends: R (>= 3.2.0)
 Imports:
-    DBI (>= 1.0.0),
+    DBI (>= 1.0.0.9003),
     methods,
     Rcpp (>= 0.12.11),
     blob (>= 1.1.0),
@@ -33,7 +33,10 @@ Suggests:
     magrittr,
     RSQLite
 LinkingTo: Rcpp, BH
+Remotes: 
+    r-dbi/DBI
 Collate: 
+    's4.R'
     'odbc.R'
     'Driver.R'
     'Connection.R'

--- a/R/odbc.R
+++ b/R/odbc.R
@@ -4,4 +4,5 @@
 #' @importFrom bit64 integer64
 #' @importFrom hms hms
 #' @useDynLib odbc, .registration = TRUE
+#' @include s4.R
 "_PACKAGE"

--- a/R/s4.R
+++ b/R/s4.R
@@ -1,0 +1,1 @@
+setMethod <- DBI::setDBIMethod


### PR DESCRIPTION
I'd like to rename the `con` argument to `sqlData()` to `conn` in r-dbi/DBI#285. This change allows me to do so in the future without introducing a breaking change which would be very unpleasant to deal with. Also, it opens up the potential to clean up the definition of the DBI interface.

See https://dbi.r-dbi.org/dev/reference/setdbimethod for details.