### PR TITLE
dbGetQuery: on.exit ensures result is destroyed

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -349,7 +349,7 @@ setMethod(
 setMethod("dbGetQuery", signature("OdbcConnection", "character"),
   function(conn, statement, n = -1, params = NULL, ...) {
     rs <- dbSendQuery(conn, statement, params = params, ...)
-    on.exit(result_release(rs@ptr))
+    on.exit(dbClearResult(rs))
 
     df <- dbFetch(rs, n = n, ...)
 

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -349,7 +349,7 @@ setMethod(
 setMethod("dbGetQuery", signature("OdbcConnection", "character"),
   function(conn, statement, n = -1, params = NULL, ...) {
     rs <- dbSendQuery(conn, statement, params = params, ...)
-    on.exit(dbClearResult(rs))
+    on.exit(result_release(rs@ptr))
 
     df <- dbFetch(rs, n = n, ...)
 

--- a/R/Result.R
+++ b/R/Result.R
@@ -44,9 +44,8 @@ setMethod(
   function(res, ...) {
     if (!dbIsValid(res)) {
       warning("Result already cleared")
-    } else {
-      result_release(res@ptr)
     }
+    result_release(res@ptr)
     invisible(TRUE)
   })
 


### PR DESCRIPTION
Hi @jimhester 

Came across an issue with the manner in which the result is cleared/released in `dbGetQuery`, especially if the `dbFetch` were to fail/throw.  In my case, because the result is not immediately released, subsequent queries also fail.  From the commit message:
```
The result is local to the method, and as is, it will get released
(and associated resources - nanodbc::statement,for example - destroyed)
on.exit with a call to `dbClearResult` and failing that once the
garbage collector engages.

If the result fetch fails/throws:
  * dbClearResult may not release the result, as the exception handler will
    mark the `current` result associated with the connection to null.
  * We may need to destroy associated resources in a more deterministic
    fashion than leaving it to the garbage collector, as the nandobc
    destructors themselves may free remote resources / reset processing
    associated with the failed statement.

This patch ensures we do that by calling `result_release` in lieu of
`dbClearResult` on exit.
```

Below I use the example from https://github.com/r-dbi/odbc/issues/10 to trigger the `dbGetQuery/dbFetch` failure, which in turn locks up subsequent valid queries until the garbage collector runs.

```
> it <- iris[1:10, c(5, 1, 2)]
> colnames(it) <- c("A", "B" ,"C")
> DBI::dbExecute(conn, "CREATE TABLE tempdb.dbo.##delete_me3 (A VARCHAR(MAX), B FLOAT, C FLOAT)")
[1] 0
> DBI::dbWriteTable(conn, value = it, name="tempdb.dbo.##delete_me3", append = TRUE, overwrite = FALSE)
[1] TRUE

# Bad / un-ordered query.  Should fail
> DBI::dbGetQuery(conn, "SELECT * FROM ##delete_me3")
Error in result_fetch(res@ptr, n) :
  nanodbc/nanodbc.cpp:2908: 00000: [Microsoft][ODBC Driver 17 for S

# Good / ordered query.  Should not fail
> DBI::dbGetQuery(conn, "SELECT B, C, A FROM ##delete_me3")
Error: nanodbc/nanodbc.cpp:1617: 00000: [Microsoft][ODBC Driver 17 for SQL Server]Conn

<SQL> 'SELECT B, C, A FROM ##delete_me3'
In addition: Warning message:
In dbClearResult(rs) : Result already cleared

# Run garbage collector.
> gc()
          used (Mb) gc trigger (Mb) max used (Mb)
Ncells  812495 43.4    1442291 77.1  1168576 62.5
Vcells 1424041 10.9    2593760 19.8  1800090 13.8

# Good / ordered query.  Should not fail
> DBI::dbGetQuery(conn, "SELECT B, C, A FROM ##delete_me3")
     B   C      A
1  5.1 3.5 setosa
2  4.9 3.0 setosa
3  4.7 3.2 setosa
4  4.6 3.1 setosa
5  5.0 3.6 setosa
6  5.4 3.9 setosa
7  4.6 3.4 setosa
8  5.0 3.4 setosa
9  4.4 2.9 setosa
10 4.9 3.1 setosa
```
Your thoughts / feedback are appreciated.
Thanks