### PR TITLE
Use correct length for varchar columns

### DIFF
--- a/R/DataTypes.R
+++ b/R/DataTypes.R
@@ -316,13 +316,25 @@ object_type <- function(obj) {
 }
 
 varchar <- function(x, type = "varchar") {
-  max_length <- max(c(1, nchar(as.character(x))), na.rm = TRUE)
-  paste0(type, "(", min(255, max_length), ")")
+  # at least 255 characters, use max if more than 8000:
+  max_length <- max(c(255, nchar(as.character(x))), na.rm = TRUE)
+
+  if (max_length > 8000) {
+    max_length <- "max"
+  }
+
+  paste0(type, "(", max_length, ")")
 }
 
 varbinary <- function(x, type = "varbinary") {
-  max_length <- max(c(1, lengths(x)), na.rm = TRUE)
-  paste0(type, "(", min(255, max_length), ")")
+  # at least 255 bytes, use max if more than 8000:
+  max_length <- max(c(255, lengths(x)), na.rm = TRUE)
+
+  if (max_length > 8000) {
+    max_length <- "max"
+  }
+
+  paste0(type, "(", max_length, ")")
 }
 
 #' Test round tripping a simple table

--- a/R/DataTypes.R
+++ b/R/DataTypes.R
@@ -316,13 +316,13 @@ object_type <- function(obj) {
 }
 
 varchar <- function(x, type = "varchar") {
-  max_length <- max(nchar(as.character(x)), na.rm = TRUE)
-  paste0(type, "(", max(255, max_length), ")")
+  max_length <- max(c(1, nchar(as.character(x))), na.rm = TRUE)
+  paste0(type, "(", min(255, max_length), ")")
 }
 
 varbinary <- function(x, type = "varbinary") {
-  max_length <- max(lengths(x), na.rm = TRUE)
-  paste0(type, "(", max(255, max_length), ")")
+  max_length <- max(c(1, lengths(x)), na.rm = TRUE)
+  paste0(type, "(", min(255, max_length), ")")
 }
 
 #' Test round tripping a simple table


### PR DESCRIPTION
on SQL Server.

Before:

``` r
odbc:::`odbcDataType.Microsoft SQL Server`(NULL, character())
#> Warning in max(nchar(as.character(x)), na.rm = TRUE): no non-missing arguments
#> to max; returning -Inf
#> [1] "varchar(255)"

odbc:::`odbcDataType.Microsoft SQL Server`(NULL, letters)
#> [1] "varchar(255)"
```

<sup>Created on 2020-01-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

After:

``` r
odbc:::`odbcDataType.Microsoft SQL Server`(NULL, character())
#> [1] "varchar(1)"

odbc:::`odbcDataType.Microsoft SQL Server`(NULL, letters)
#> [1] "varchar(1)"
```

<sup>Created on 2020-01-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>