### PR TITLE
wrap table name in toString() when throwing errors from odbc_write_table

### DIFF
--- a/R/Table.R
+++ b/R/Table.R
@@ -38,7 +38,7 @@ odbc_write_table <-
 
     found <- dbExistsTable(conn, name)
     if (found && !overwrite && !append) {
-      stop("Table ", name, " exists in database, and both overwrite and",
+      stop("Table ", toString(name), " exists in database, and both overwrite and",
         " append are FALSE", call. = FALSE)
     }
     if (found && overwrite) {


### PR DESCRIPTION
fixes #339