### PR TITLE
Fetch all result sets

### DIFF
--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -2452,6 +2452,8 @@ public:
             return false;
         if (!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
+        row_count_ = 0;
+        rowset_position_ = 0;
         auto_bind();
         return true;
     }

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -727,6 +727,13 @@ Rcpp::List odbc_result::result_to_dataframe(nanodbc::result& r, int n_max) {
     if (rows_fetched_ % 16384 == 0) {
       Rcpp::checkUserInterrupt();
     }
+
+    if (complete_) {
+      complete_ = !r.next_result();
+      if (!complete_) {
+        complete_ = !r.next();
+      }
+    }
   }
 
   // Resize if needed

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -729,10 +729,12 @@ Rcpp::List odbc_result::result_to_dataframe(nanodbc::result& r, int n_max) {
     }
 
     if (complete_) {
-      complete_ = !r.next_result();
-      if (!complete_) {
-        complete_ = !r.next();
-      }
+      while (r.next_result()) {
+        if (r.next()) {
+          complete_ = false;
+          break;
+        }
+      };
     }
   }
 


### PR DESCRIPTION
As demonstrated by the example below, parameterized queries are broken in existing code because `dbFetch` ignores multiple result sets. 

* The issue affects SQL Server straight away, as the driver will return a result set for each parameter set. 
* In addition, the issue affects MySQL and every other driver indirectly, as `dbBind` submits parameter sets in batches of  `batch_rows = getOption("odbc.batch_rows", 1024)`.

--- 

Example sscript:
``` R
library(DBI)

dev_db <- dbConnect(odbc::odbc(), "dev_db")

df <- data.frame(id = 1:1026)

if (dbExistsTable(dev_db, "df")) dbRemoveTable(dev_db, "df")
dbCreateTable(dev_db, "df", df)


sql <- "INSERT INTO df (id) VALUES (?)"
rs <- dbSendStatement(dev_db, sql)
dbBind(rs, df)
dbClearResult(rs)

print(tail(dbReadTable(dev_db, "df")))

sql <- "SELECT id FROM df WHERE id=?"
rs <- dbSendQuery(dev_db, sql)
dbBind(rs, df)
results <- dbFetch(rs)
dbClearResult(rs)

print(results)

dbDisconnect(dev_db)
```

---
Example SQL Server results:
```
    id
1 1025
```

---
Example MySQL results:
```
    id
1 1025
2 1026
```
