### PR TITLE
WIP: Catch errors from calling SQLGetData()

### DIFF
--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -770,15 +770,19 @@ void odbc_result::assign_string(
     // SQLGetData()
     // has been called for that column (i.e. after get() or get_ref() is
     // called).
-    auto str = value.get<std::string>(column);
-    if (value.is_null(column)) {
-      res = NA_STRING;
-    } else {
-      if (c_->encoding() != "") {
-        res = output_encoder_.makeSEXP(str.c_str(), str.c_str() + str.length());
-      } else { // If no encoding specified assume it is UTF-8 / ASCII
-        res = Rf_mkCharCE(str.c_str(), CE_UTF8);
+    try {
+      auto str = value.get<std::string>(column);
+      if (value.is_null(column)) {
+        res = NA_STRING;
+      } else {
+        if (c_->encoding() != "") {
+          res = output_encoder_.makeSEXP(str.c_str(), str.c_str() + str.length());
+        } else { // If no encoding specified assume it is UTF-8 / ASCII
+          res = Rf_mkCharCE(str.c_str(), CE_UTF8);
+        }
       }
+    } catch (const nanodbc::database_error& e) {
+      res = NA_STRING;
     }
   }
   SET_STRING_ELT(out[column], row, res);


### PR DESCRIPTION
This is a proof of concept to catch errors from drivers that don't implement the `SQL_GD_ANY_COLUMN` extension. It shows that we can query more columns and rows even after `SQLGetData()` fails.

We could then:

- distinguish 07009 errors from others, https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/appendix-a-odbc-error-codes
- record all failures
- raise a warning that indicates which columns could not be retrieved
- suggest remedies in that warning, and point to appropriate resources
    - we can't rely on `SQLGetInfo()` for all drivers, but in case of a failure we can check if the `SQL_GD_ANY_COLUMN` extension is supported and warn appropriately)

Closes #358.

``` r
library(DBI)
library(tidyverse)

con <- dbConnect(odbc::odbc(), "mssql-test-ms", uid = "kirill", pwd = keyring::key_get("mssql", "kirill"))

data <- tibble(a = 1:3, b = "a", c = 1)

copy_to(con, data, name = "##data1", types = c("integer", "varchar(max)", "real")) %>% collect()
#> # A tibble: 3 x 3
#>       a b         c
#>   <int> <chr> <dbl>
#> 1     1 <NA>      1
#> 2     2 <NA>      1
#> 3     3 <NA>      1
```

<sup>Created on 2020-04-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>