### PR TITLE
Use immediate = TRUE for dbWriteTable()

### DIFF
--- a/R/Table.R
+++ b/R/Table.R
@@ -49,7 +49,7 @@ odbc_write_table <-
 
     if (!found || overwrite) {
       sql <- sqlCreateTable(conn, name, values, field.types = field.types, row.names = FALSE, temporary = temporary)
-      dbExecute(conn, sql)
+      dbExecute(conn, sql, immediate = TRUE)
     }
 
     fieldDetails <- tryCatch({


### PR DESCRIPTION
Otherwise, on SQL Server:

``` r
library(DBI)

con <- dbConnect(odbc::odbc(), "mssql-test", uid = "kirill", pwd = keyring::key_get("mssql", "kirill"))

data <- tibble::tibble(a = 1:3, b = "a", c = 1)
dbWriteTable(con, "#data", data)
dbReadTable(con, "#data")
#> Error: nanodbc/nanodbc.cpp:1617: 00000: [FreeTDS][SQL Server]Invalid object name '#data'.  [FreeTDS][SQL Server]Statement(s) could not be prepared. 
#> <SQL> 'SELECT * FROM "#data"'
```

<sup>Created on 2020-04-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>