### PR TITLE
Catch exception by value to avoid OOB access

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -42,7 +42,9 @@ odbc_connection::odbc_connection(
 
   try {
     c_ = std::make_shared<nanodbc::connection>(connection_string, timeout);
-  } catch (const nanodbc::database_error& e) {
+  } catch (nanodbc::database_error e) {
+    // Catching const nanodbc::database_error& e leads to
+    // OOB memory access.
     throw Rcpp::exception(e.what(), FALSE);
   }
 }


### PR DESCRIPTION
I have no idea why this is necessary, nanodbc and Rcpp seem to be doing the right thing otherwise. Should we also catch by value when fetching the result?

Reproducible with:

```
R -d valgrind -q -e 'pkgload::load_all(); DBI::dbConnect(odbc(), list(dsn = "bogus"))'
```