### PR TITLE
Prcandidate/out of order blob

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ Authors@R:
              family = "Wickham",
              role = "aut",
              email = "hadley@rstudio.com"),
+      person(given = "detule", role = "ctb"),
       person(given = "lexicalunit",
              role = "cph",
              comment = "nanodbc library"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R:
              family = "Wickham",
              role = "aut",
              email = "hadley@rstudio.com"),
-      person(given = "detule", role = "ctb"),
+      person(given = "Oliver", "Gjoneski", role = "ctb", note = "detule"),
       person(given = "lexicalunit",
              role = "cph",
              comment = "nanodbc library"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # odbc (development version)
 
+* `invalid descriptor` issues due to out of order retrieval of long columns are now avoided by unbinding any nanodbc buffer past the long column. Performance for the unbound columns in these cases will be reduced, but the retrieval will work (@detule, #381)
+
 # odbc 1.2.3
 
 * `dbWriteTable()` now executes immediately, which fixes issues with temporary tables and the FreeTDS SQL Server driver (@krlmlr).

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -622,6 +622,7 @@ public:
         , blob_(false)
         , cbdata_(0)
         , pdata_(0)
+        , bound_(false)
     {
     }
 
@@ -642,6 +643,7 @@ public:
     bool blob_;
     nanodbc::null_type* cbdata_;
     char* pdata_;
+    bool bound_;
 };
 
 // Encapsulates properties of statement parameter.
@@ -2363,6 +2365,19 @@ public:
         return is_null(column);
     }
 
+    bool is_bound(short column) const
+    {
+        throw_if_column_is_out_of_range(column);
+        bound_column& col = bound_columns_[column];
+        return col.bound_;
+    }
+
+    bool is_bound(const string_type& column_name) const
+    {
+        const short column = this->column(column_name);
+        return is_bound(column);
+    }
+
     short column(const string_type& column_name) const
     {
         typedef std::map<string_type, bound_column*>::const_iterator iter;
@@ -2456,6 +2471,46 @@ public:
         return true;
     }
 
+    void unbind()
+    {
+        const short n_columns = columns();
+        if (n_columns < 1)
+            return;
+        for (short i = 0; i < n_columns; ++i)
+            unbind(i);
+    }
+
+    void unbind(short column)
+    {
+        RETCODE rc;
+        throw_if_column_is_out_of_range(column);
+        bound_column& col = bound_columns_[column];
+
+        if (is_bound(column))
+        {
+            NANODBC_CALL_RC(
+                SQLBindCol,
+                rc,
+                stmt_.native_statement_handle(),
+                column + 1,
+                col.ctype_,
+                0,
+                0,
+                col.cbdata_); // Re-use existing cbdata_ buffer
+            if (!success(rc))
+                NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
+            delete[] col.pdata_;
+            col.pdata_ = 0;
+            col.bound_ = false;
+        }
+    }
+
+    void unbind(const string_type& column_name)
+    {
+        const short column = this->column(column_name);
+        unbind(column);
+    }
+
     template <class T>
     void get_ref(short column, T& result) const
     {
@@ -2533,8 +2588,17 @@ public:
     }
 
 private:
+    template <typename T>
+    T* ensure_pdata(short column) const;
+
     template <class T>
     void get_ref_impl(short column, T& result) const;
+
+    void throw_if_column_is_out_of_range(short column) const
+    {
+        if ((column < 0) || (column >= bound_columns_size_))
+            throw index_range_error();
+    }
 
     void before_move() NANODBC_NOEXCEPT
     {
@@ -2772,6 +2836,7 @@ private:
                     col.cbdata_); // StrLen_or_Ind
                 if (!success(rc))
                     NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
+                col.bound_ = true;
             }
         }
     }
@@ -2797,11 +2862,11 @@ inline void result::result_impl::get_ref_impl<date>(short column, date& result) 
     switch (col.ctype_)
     {
     case SQL_C_DATE:
-        result = *reinterpret_cast<date*>(col.pdata_ + rowset_position_ * col.clen_);
+        result = *ensure_pdata<date>(column);
         return;
     case SQL_C_TIMESTAMP:
     {
-        timestamp stamp = *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
+        timestamp stamp = *ensure_pdata<timestamp>(column);
         date d = {stamp.year, stamp.month, stamp.day};
         result = d;
         return;
@@ -2817,11 +2882,11 @@ inline void result::result_impl::get_ref_impl<time>(short column, time& result) 
     switch (col.ctype_)
     {
     case SQL_C_TIME:
-        result = *reinterpret_cast<time*>(col.pdata_ + rowset_position_ * col.clen_);
+        result = *ensure_pdata<time>(column);
         return;
     case SQL_C_TIMESTAMP:
     {
-        timestamp stamp = *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
+        timestamp stamp = *ensure_pdata<timestamp>(column);
         time t = {stamp.hour, stamp.min, stamp.sec};
         result = t;
         return;
@@ -2838,13 +2903,13 @@ inline void result::result_impl::get_ref_impl<timestamp>(short column, timestamp
     {
     case SQL_C_DATE:
     {
-        date d = *reinterpret_cast<date*>(col.pdata_ + rowset_position_ * col.clen_);
+        date d = *ensure_pdata<date>(column);
         timestamp stamp = {d.year, d.month, d.day, 0, 0, 0, 0};
         result = stamp;
         return;
     }
     case SQL_C_TIMESTAMP:
-        result = *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
+        result = *ensure_pdata<timestamp>(column);
         return;
     }
     throw type_incompatible_error();
@@ -2861,7 +2926,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
     case SQL_C_CHAR:
     case SQL_C_BINARY:
     {
-        if (col.blob_)
+        if (!is_bound(column))
         {
             // Input is always std::string, while output may be std::string or wide_string_type
             std::string out;
@@ -2908,7 +2973,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                 NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
         }
         else
-        {
+        { // bound and not blob
             const char* s = col.pdata_ + rowset_position_ * col.clen_;
             const std::string::size_type str_size = std::strlen(s);
             result.assign(s, s + str_size);
@@ -2918,7 +2983,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
 
     case SQL_C_WCHAR:
     {
-        if (col.blob_)
+        if (!is_bound(column))
         {
             // Input is always wide_string_type, output might be std::string or wide_string_type.
             // Use a string builder to build the output string.
@@ -2967,7 +3032,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
             ;
         }
         else
-        {
+        { // bound and not blob
             // Type is unicode in the database, convert if necessary
             const SQLWCHAR* s =
                 reinterpret_cast<SQLWCHAR*>(col.pdata_ + rowset_position_ * col.clen_);
@@ -2986,7 +3051,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
         buffer.resize(buffer.capacity());
         using std::fill;
         fill(buffer.begin(), buffer.end(), '\0');
-        const int32_t data = *reinterpret_cast<int32_t*>(col.pdata_ + rowset_position_ * col.clen_);
+        const int32_t data = *ensure_pdata<int32_t>(column);
         const int bytes =
             std::snprintf(const_cast<char*>(buffer.data()), column_size + 1, "%d", data);
         if (bytes == -1)
@@ -3007,8 +3072,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
         buffer.resize(buffer.capacity());
         using std::fill;
         fill(buffer.begin(), buffer.end(), '\0');
-        const intmax_t data =
-            (intmax_t) * reinterpret_cast<int64_t*>(col.pdata_ + rowset_position_ * col.clen_);
+        const intmax_t data = (intmax_t)*ensure_pdata<int64_t>(column);
         const int bytes =
             std::snprintf(const_cast<char*>(buffer.data()), column_size + 1, "%jd", data);
         if (bytes == -1)
@@ -3028,7 +3092,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
         buffer.resize(buffer.capacity());
         using std::fill;
         fill(buffer.begin(), buffer.end(), '\0');
-        const float data = *reinterpret_cast<float*>(col.pdata_ + rowset_position_ * col.clen_);
+        const float data = *ensure_pdata<float>(column);
         const int bytes =
             std::snprintf(const_cast<char*>(buffer.data()), column_size + 1, "%f", data);
         if (bytes == -1)
@@ -3049,7 +3113,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
         buffer.resize(buffer.capacity());
         using std::fill;
         fill(buffer.begin(), buffer.end(), '\0');
-        const double data = *reinterpret_cast<double*>(col.pdata_ + rowset_position_ * col.clen_);
+        const double data = *ensure_pdata<double>(column);
         const int bytes = std::snprintf(
             const_cast<char*>(buffer.data()),
             width + 1,
@@ -3068,7 +3132,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
 
     case SQL_C_DATE:
     {
-        const date d = *reinterpret_cast<date*>(col.pdata_ + rowset_position_ * col.clen_);
+        const date d = *ensure_pdata<date>(column);
         std::tm st = {};
         st.tm_year = d.year - 1900;
         st.tm_mon = d.month - 1;
@@ -3084,7 +3148,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
 
     case SQL_C_TIME:
     {
-        const time t = *reinterpret_cast<time*>(col.pdata_ + rowset_position_ * col.clen_);
+        const time t = *ensure_pdata<time>(column);
         std::tm st = {};
         st.tm_hour = t.hour;
         st.tm_min = t.min;
@@ -3100,8 +3164,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
 
     case SQL_C_TIMESTAMP:
     {
-        const timestamp stamp =
-            *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
+        const timestamp stamp = *ensure_pdata<timestamp>(column);
         std::tm st = {};
         st.tm_year = stamp.year - 1900;
         st.tm_mon = stamp.month - 1;
@@ -3133,7 +3196,7 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
     {
     case SQL_C_BINARY:
     {
-        if (col.blob_)
+        if (!is_bound(column))
         {
             // Input and output is always array of bytes.
             std::vector<std::uint8_t> out;
@@ -3190,43 +3253,75 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
     throw type_incompatible_error();
 }
 
+template <typename T>
+T* result::result_impl::ensure_pdata(short column) const
+{
+    bound_column& col = bound_columns_[column];
+    SQLLEN ValueLenOrInd;
+    SQLRETURN rc;
+    if (is_bound(column))
+    {
+        return (T*)(col.pdata_ + rowset_position_ * col.clen_);
+    }
+
+    T* buffer = new T;
+    const std::size_t buffer_size = sizeof(T);
+    void* handle = native_statement_handle();
+    NANODBC_CALL_RC(
+        SQLGetData,
+        rc,
+        handle,              // StatementHandle
+        column + 1,          // Col_or_Param_Num
+        sql_ctype<T>::value, // TargetType
+        buffer,              // TargetValuePtr
+        buffer_size,         // BufferLength
+        &ValueLenOrInd);     // StrLen_or_IndPtr
+
+    if (ValueLenOrInd == SQL_NULL_DATA)
+        col.cbdata_[static_cast<size_t>(rowset_position_)] = (SQLINTEGER)SQL_NULL_DATA;
+    if (!success(rc))
+        NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
+    NANODBC_ASSERT(ValueLenOrInd == (SQLLEN)buffer_size);
+
+    return buffer;
+}
+
 template <class T>
 void result::result_impl::get_ref_impl(short column, T& result) const
 {
     bound_column& col = bound_columns_[column];
     using namespace std; // if int64_t is in std namespace (in c++11)
-    const char* s = col.pdata_ + rowset_position_ * col.clen_;
     switch (col.ctype_)
     {
     case SQL_C_CHAR:
-        result = (T) * (char*)(s);
+        result = (T) * (ensure_pdata<char>(column));
         return;
     case SQL_C_SSHORT:
-        result = (T) * (short*)(s);
+        result = (T) * (ensure_pdata<short>(column));
         return;
     case SQL_C_USHORT:
-        result = (T) * (unsigned short*)(s);
+        result = (T) * (ensure_pdata<unsigned short>(column));
         return;
     case SQL_C_LONG:
-        result = (T) * (int32_t*)(s);
+        result = (T) * (ensure_pdata<int32_t>(column));
         return;
     case SQL_C_SLONG:
-        result = (T) * (int32_t*)(s);
+        result = (T) * (ensure_pdata<int32_t>(column));
         return;
     case SQL_C_ULONG:
-        result = (T) * (uint32_t*)(s);
+        result = (T) * (ensure_pdata<uint32_t>(column));
         return;
     case SQL_C_FLOAT:
-        result = (T) * (float*)(s);
+        result = (T) * (ensure_pdata<float>(column));
         return;
     case SQL_C_DOUBLE:
-        result = (T) * (double*)(s);
+        result = (T) * (ensure_pdata<double>(column));
         return;
     case SQL_C_SBIGINT:
-        result = (T) * (int64_t*)(s);
+        result = (T) * (ensure_pdata<int64_t>(column));
         return;
     case SQL_C_UBIGINT:
-        result = (T) * (uint64_t*)(s);
+        result = (T) * (ensure_pdata<uint64_t>(column));
         return;
     }
     throw type_incompatible_error();
@@ -4638,6 +4733,16 @@ bool result::is_null(const string_type& column_name) const
     return impl_->is_null(column_name);
 }
 
+bool result::is_bound(short column) const
+{
+    return impl_->is_bound(column);
+}
+
+bool result::is_bound(const string& column_name) const
+{
+    return impl_->is_bound(column_name);
+}
+
 short result::column(const string_type& column_name) const
 {
     return impl_->column(column_name);
@@ -4691,6 +4796,21 @@ int result::column_c_datatype(const string_type& column_name) const
 bool result::next_result()
 {
     return impl_->next_result();
+}
+
+void result::unbind()
+{
+    impl_->unbind();
+}
+
+void result::unbind(short column)
+{
+    impl_->unbind(column);
+}
+
+void result::unbind(const string_type& column_name)
+{
+    impl_->unbind(column_name);
 }
 
 template <class T>

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -2979,13 +2979,6 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
         return;
     }
 
-    case SQL_C_GUID:
-    {
-        const char* s = col.pdata_ + rowset_position_ * col.clen_;
-        result.assign(s, s + column_size);
-        return;
-    }
-
     case SQL_C_LONG:
     {
         std::string buffer;

--- a/src/nanodbc/nanodbc.h
+++ b/src/nanodbc/nanodbc.h
@@ -1256,6 +1256,36 @@ public:
     /// \brief Returns true if there are no more results in the current result set.
     bool at_end() const NANODBC_NOEXCEPT;
 
+    /// \brief Unbind data buffers for all columns in the result set.
+    ///
+    /// Wraps unbind(short column)
+    /// \throws index_range_error, database_error
+    void unbind();
+
+    /// \brief Unbind data buffers for specific columns in the result set.
+    ///
+    /// Wraps unbind(short column)
+    ///
+    /// \param column_name string Name of column we wish to unbind.
+    /// \throws index_range_error, database_error
+    void unbind(const string_type& column_name);
+
+    /// \brief Unbind data buffers for specific columns in the result set.
+    ///
+    /// When a result is constructed, in order to optimize data retrieval,
+    /// we automatically try to bind buffers, except for columns that contain
+    /// long/blob data types.  This method gives the caller the option to unbind
+    /// a specific buffer.  Subsequently, during calls to get(), if there is no
+    /// bound data buffer, we will attempt to retrieve the data using a call
+    /// SQLGetData; this is similar to the route taken for columns hosting long
+    /// or bloby data types.  This is suboptimal from efficiency perspective,
+    /// however may be necessary of the driver we are communicating with does
+    /// not support out-of-order retrieval of long data.
+    ///
+    /// \param column short Zero-based index of column we wish to unbind.
+    /// \throws index_range_error, database_error
+    void unbind(short column);
+
     /// \brief Gets data from the given column of the current rowset.
     ///
     /// Columns are numbered from left to right and 0-indexed.
@@ -1353,6 +1383,26 @@ public:
     /// \param column_name column's name.
     /// \throws database_error, index_range_error
     bool is_null(const string_type& column_name) const;
+
+    /// \brief Returns true if we have bound a buffer to the given column.
+    ///
+    /// Generically, nanodbc will greedily bind buffers to columns in the result
+    /// set.  However, we have also given the user the ability to unbind buffers
+    /// via unbind() forcing nanodbc to retrieve data via SQLGetData.  This
+    /// method returns true if there is a buffer bound to the column.
+    ///
+    /// Columns are numbered from left to right and 0-indexed.
+    /// \param column short position.
+    /// \throws index_range_error
+    bool is_bound(short column) const;
+
+    /// \brief Returns true if we have bound a buffer to the given column.
+    ///
+    /// See is_bound(short column) for details.
+    /// \see is_bound()
+    /// \param column_name column's name.
+    /// \throws index_range_error
+    bool is_bound(const string_type& column_name) const;
 
     /// \brief Returns the column number of the specified column name.
     ///

--- a/src/odbc_connection.h
+++ b/src/odbc_connection.h
@@ -34,6 +34,7 @@ public:
   bool has_active_result() const;
   bool is_current_result(odbc_result* result) const;
   bool supports_transactions() const;
+  bool get_data_any_order() const;
 
   void set_current_result(odbc_result* r);
 

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -71,6 +71,7 @@ private:
   std::map<short, std::vector<uint8_t>> nulls_;
 
   void clear_buffers();
+  void unbind_if_needed();
 
   void bind_columns(
       nanodbc::statement& statement,

--- a/tests/testthat/test-SQLServer.R
+++ b/tests/testthat/test-SQLServer.R
@@ -156,4 +156,20 @@ test_that("SQLServer", {
       "Columns in `field.types` must be in the input"
     )
   })
+
+  local({
+    con <- DBItest:::connect(DBItest:::get_default_context())
+    tblName <- "test_out_of_order_blob"
+
+    values <- data.frame(
+      c1 = 1,
+      c2 = "this is varchar max",
+      c3 = 11,
+      c4 = "this is text",
+      stringsAsFactors = FALSE)
+    dbWriteTable(con, tblName, values, field.types = list(c1 = "INT", c2 = "VARCHAR(MAX)", c3 = "INT", c4 = "TEXT"))
+    on.exit(dbRemoveTable(con, tblName))
+    received <- DBI::dbReadTable(con, tblName)
+    expect_equal(values, received)
+  })
 })


### PR DESCRIPTION
Hi @jimhester 

This is one approach to tackling the infamous "invalid descriptor" problem.  The idea is: If driver is such that out-of-order-retrieval via `SQLGetData` is not possible then unbind all `nanodbc` buffers past the first unbound (blob) column.

First two patches are a clean-ish backport of the upstream patches that introduce the 'result::unbind' endpoint - but more importantly, route calls to `get<T>` to `SQLGetData` if there is no bound buffer.  Previously this (no buffer bound to the column) was the case only for blobs, but now it's possible for non-blobby columns if the user asked these to be unbound.

Second two are `package:odbc` patches that implement the "unbind-if-necessary" logic.  `connection::get_data_any_order` is particularly ugly - happy to make updates there and elsewhere.

Thanks