### PR TITLE
Fix compilation on Alpine Linux

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -14,7 +14,7 @@ $(OBJECTS): cctz/libcctz.a
 
 cctz/libcctz.a:
 	(cd cctz && \
-$(MAKE) libcctz.a CC="$(CC)" CXX="$(CXX)" AR="$(AR)" ARFLAGS=$(ARFLAGS) CXXPICFLAGS="$(CXXPICFLAGS)")
+$(MAKE) libcctz.a CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS)" AR="$(AR)" ARFLAGS=$(ARFLAGS) CXXPICFLAGS="$(CXXPICFLAGS)")
 
 nanodbc.o: nanodbc/nanodbc.cpp
 	$(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) -c $< -o $@

--- a/src/cctz/src/time_zone_info.cc
+++ b/src/cctz/src/time_zone_info.cc
@@ -57,7 +57,7 @@ char* errmsg(int errnum, char* buf, size_t buflen) {
 #elif defined(__APPLE__)
   strerror_r(errnum, buf, buflen);
   return buf;
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE
+#elif ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE) || __MUSL__
   strerror_r(errnum, buf, buflen);
   return buf;
 #else


### PR DESCRIPTION
* Pass down `CXXFLAGS` to libcctz. On https://github.com/r-hub/r-minimal
  we set `__MUSL__`. This is not a standard, but nevertheless some
  R packages (e.g. Rcpp) rely on it already, and at least the user
  can set it in a user Makevars file.
* Use `__MUSL__` to select the right `strerror_r` signature. I don't know
  why this is not happening automatically. It might be a libcctz
  bug or a musl bug.