### PR TITLE
should check validity before clearing results

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -352,7 +352,7 @@ setMethod(
 setMethod("dbGetQuery", signature("OdbcConnection", "character"),
   function(conn, statement, n = -1, params = NULL, ...) {
     rs <- dbSendQuery(conn, statement, params = params, ...)
-    on.exit(dbClearResult(rs))
+    on.exit(if (dbIsValid(rs)) dbClearResult(rs))
 
     df <- dbFetch(rs, n = n, ...)
 


### PR DESCRIPTION
For certain cases, e.g., `select A/B from Table` where the B column contains zero, the `rs` object would have become invalid already after fetching. This leads to a case that odbc throws warning complaining "Result already cleared".

This PR fixes that.

I think it's really trival so I think without a NEWs item and test should be fine. However, if you think they are necessary, please let me know.

Thanks.
