### PR TITLE
Fixup/null detection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* Fixed null handling in SQL Server / Azure result sets retrieved with
+  Microsoft's ODBC driver. (@detule, #408)
+
 # odbc 1.3.0
 
 ## Major changes


### PR DESCRIPTION
Hi @jimhester 

Now that we may encounter unbound columns more broadly (not just with LONG columns) we need to extend the check-for-nullity-after-get to all column types.

This should fix https://github.com/r-dbi/odbc/issues/408

Thanks