### PR TITLE
Invalid descriptor with prepared SELECTs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # odbc (development version)
 
+* Fixed `invalid descriptor` issues when retrieving results from SQL Server +
+  Microsoft's ODBC driver, using parametrized queries. (@detule, #414)
 * Fixed null handling in SQL Server / Azure result sets retrieved with
   Microsoft's ODBC driver. (@detule, #408)
 

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -31,7 +31,6 @@ odbc_result::odbc_result(
       execute();
     }
   }
-  unbind_if_needed();
 }
 std::shared_ptr<odbc_connection> odbc_result::connection() const {
   return std::shared_ptr<odbc_connection>(c_);
@@ -171,6 +170,7 @@ Rcpp::DataFrame odbc_result::fetch(int n_max) {
   if (num_columns_ == 0) {
     return Rcpp::DataFrame();
   }
+  unbind_if_needed();
   try {
     return result_to_dataframe(*r_, n_max);
   } catch (...) {

--- a/tests/testthat/test-SQLServer.R
+++ b/tests/testthat/test-SQLServer.R
@@ -145,7 +145,11 @@ test_that("SQLServer", {
     dbWriteTable(con, tblName, values, field.types = list(c1 = "INT", c2 = "VARCHAR(MAX)", c3 = "INT", c4 = "TEXT"))
     on.exit(dbRemoveTable(con, tblName))
     received <- DBI::dbReadTable(con, tblName)
+    # Also test retrival using a prepared statement
+    received2 <- dbGetQuery(con,
+      paste0("SELECT * FROM ", tblName, "  WHERE c1 = ?"), params = list(1L))
     expect_equal(values, received)
+    expect_equal(values, received2)
   })
 
   local({


### PR DESCRIPTION
Hi @jimhester - this moves the `unbind_if_needed` call to be part of the fetch operation - rather than when the the result is constructed.

Fixes https://github.com/r-dbi/odbc/issues/414