### PR TITLE
Fail if database is missing

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -2,10 +2,19 @@ skip_unless_has_test_db <- function(expr) {
   if (!identical(Sys.getenv("NOT_CRAN"), "true")) {
     return(skip("On CRAN"))
   }
-  tryCatch({
-    DBItest:::connect(expr)
+
+  # Failing database connection should fail the test in DBItest backends
+  if (Sys.getenv("DBITEST_BACKENDS") != "") {
+    con <- DBItest:::connect(expr)
+    DBI::dbDisconnect(con)
     TRUE
-  }, error = function(e) {
-    skip(paste0("Test database not available:\n'", conditionMessage(e), "'"))
-  })
+  } else {
+    tryCatch({
+      con <- DBItest:::connect(expr)
+      DBI::dbDisconnect(con)
+      TRUE
+    }, error = function(e) {
+      skip(paste0("Test database not available:\n'", conditionMessage(e), "'"))
+    })
+  }
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -4,7 +4,7 @@ skip_unless_has_test_db <- function(expr) {
   }
 
   # Failing database connection should fail the test in DBItest backends
-  if (Sys.getenv("DBITEST_BACKENDS") != "") {
+  if (nzchar(Sys.getenv("DBITEST_BACKENDS"))) {
     con <- DBItest:::connect(expr)
     DBI::dbDisconnect(con)
     TRUE


### PR DESCRIPTION
if `DBITEST_BACKENDS` environment variable is set.

I'm adding odbc to the downstream tests in https://github.com/r-dbi/DBItest/pull/224, I'd like the tests to fail in this case if no database connection can be established.