### PR TITLE
Fix SQL server test

### DIFF
--- a/tests/testthat/test-SQLServer.R
+++ b/tests/testthat/test-SQLServer.R
@@ -174,7 +174,7 @@ test_that("SQLServer", {
 
   test_that("dates should always be interpreted in the system time zone (#398)", {
     con <- DBItest:::connect(DBItest:::get_default_context(), timezone = "America/Chicago")
-    res <- dbGetQuery(con, "SELECT ?", params = as.Date("2019-01-01"))
-    expect_equal(res[[1]], "2019-01-01")
+    res <- dbGetQuery(con, "SELECT CAST(? AS date)", params = as.Date("2019-01-01"))
+    expect_equal(res[[1]], as.Date("2019-01-01"))
   })
 })


### PR DESCRIPTION
for date roundtrip.

The original test returns the input as a string, for me on both FreeTDS and MSSQL 17 drivers. However, the new test doesn't seem to touch the code path changed in 42a8275879a195eb7b206ea6fc3a60e8a62c03ca (#398), that commit changed `as_timestamp()` but we're using `as_date()` here AFAICT?