### PR TITLE
Fix single schema RStudio Connections pane issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
   and ends with `ON COMMIT PRESERVE ROWS` (DB2's default behavior is
   `ON COMMIT DELETE ROWS`, which results in the inserted data being
   deleted as soon as `dbWriteTable` completes). (@rnorberg, #426)
+* Fixed RStudio Connections Pane when working with a database that has only one catalog or one schema. (@meztez, #)
 
 # odbc 1.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
   and ends with `ON COMMIT PRESERVE ROWS` (DB2's default behavior is
   `ON COMMIT DELETE ROWS`, which results in the inserted data being
   deleted as soon as `dbWriteTable` completes). (@rnorberg, #426)
-* Fixed RStudio Connections Pane when working with a database that has only one catalog or one schema. (@meztez, #)
+* Fixed RStudio Connections Pane when working with a database that has only one catalog or one schema. (@meztez, #444)
 
 # odbc 1.3.0
 

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -46,13 +46,13 @@ odbcListObjectTypes.default <- function(connection) {
 
   # check for multiple schema or a named schema
   schemas <- string_values(connection_sql_tables(connection@ptr, "", "%", "", "")[["table_schema"]])
-  if (length(schemas) > 1) {
+  if (length(schemas) > 0) {
     obj_types <- list(schema = list(contains = obj_types))
   }
 
   # check for multiple catalogs
   catalogs <- string_values(connection_sql_tables(connection@ptr, "%", "", "", "")[["table_catalog"]])
-  if (length(catalogs) > 1) {
+  if (length(catalogs) > 0) {
     obj_types <- list(catalog = list(contains = obj_types))
   }
 
@@ -84,8 +84,8 @@ odbcListObjects.OdbcConnection <- function(connection, catalog = NULL, schema = 
   # if no catalog was supplied but this database has catalogs, return a list of
   # catalogs
   if (is.null(catalog)) {
-    catalogs <- string_values(connection_sql_tables(connection@ptr, catalog_name = catalog %||% "%", "", "", NULL)[["table_catalog"]])
-    if (length(catalogs) > 1) {
+    catalogs <- string_values(connection_sql_tables(connection@ptr, catalog_name = "%", "", "", NULL)[["table_catalog"]])
+    if (length(catalogs) > 0) {
       return(
         data.frame(
           name = catalogs,
@@ -98,8 +98,8 @@ odbcListObjects.OdbcConnection <- function(connection, catalog = NULL, schema = 
   # if no schema was supplied but this database has schema, return a list of
   # schema
   if (is.null(schema)) {
-    schemas <- string_values(connection_sql_tables(connection@ptr, "", schema_name = schema %||% "%", "", NULL)[["table_schema"]])
-    if (length(schemas) > 1) {
+    schemas <- string_values(connection_sql_tables(connection@ptr, "", "%", "", NULL)[["table_schema"]])
+    if (length(schemas) > 0) {
       return(
         data.frame(
           name = schemas,


### PR DESCRIPTION
HI,

First, thanks to the maintainers for all the great contributions. We all appreciate the time you put in.

The following statements might be wrong as they are my personal understanding.

I think the conditions in `odbcListObjects` should be greater than 0 instead of greater than 1. I could not a reason to recheck for nullity with %||% it is checked one line above.

Furthermore, I've tested it on MSSQL, Netezza. Works fine.

It fixes an issue with a db that has only one schema as the tables would be listed, but the Preview would fail because no schema would be fed to the preview function.

Have an excellen day.