### PR TITLE
Adds custom data types method for Snowflake DBs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # odbc (development version)
 
+* New `odbcDataType.Snowflake()` method for Snowflake databases. (@edgararuiz, #451)
+
 # odbc 1.3.1
 
 * Fixed warnings about anonymous unions (@detule, #440)

--- a/R/DataTypes.R
+++ b/R/DataTypes.R
@@ -296,7 +296,8 @@ odbcDataType.Oracle <- function(con, obj, ...) {
   )
 }
 
-odbcDataType.Snowflake <- function(con, obj, ...) {
+#' @export
+`odbcDataType.Snowflake` <- function(con, obj, ...) {
   switch_type(
     obj,
     factor = "VARCHAR(255)",

--- a/R/DataTypes.R
+++ b/R/DataTypes.R
@@ -299,10 +299,19 @@ odbcDataType.Oracle <- function(con, obj, ...) {
 odbcDataType.Snowflake <- function(con, obj, ...) {
   switch_type(
     obj,
+    factor = "VARCHAR(255)",
+    datetime = "TIMESTAMP",
+    date = "DATE",
+    time = "TIME",
+    binary = "VARBINARY(255)",
+    integer = "INTEGER",
+    double = "DOUBLE PRECISION",
+    character = "VARCHAR(255)",
     logical = "BOOLEAN",
+    list = "VARCHAR(255)",
     stop("Unsupported type", call. = FALSE)
   )
-  }
+}
 
 switch_type <- function(obj, ...) {
   switch(object_type(obj), ...)

--- a/R/DataTypes.R
+++ b/R/DataTypes.R
@@ -296,6 +296,14 @@ odbcDataType.Oracle <- function(con, obj, ...) {
   )
 }
 
+odbcDataType.Snowflake <- function(con, obj, ...) {
+  switch_type(
+    obj,
+    logical = "BOOLEAN",
+    stop("Unsupported type", call. = FALSE)
+  )
+  }
+
 switch_type <- function(obj, ...) {
   switch(object_type(obj), ...)
 }


### PR DESCRIPTION
- Adds custom `odbcDataType()` for Snowflake
- Only difference from default was to use BOOLEAN instead of BIT for `logical` var conversion
