### PR TITLE
Db2 find temp tables in dbExistsTable and dbListTables

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -91,3 +91,43 @@ setMethod("sqlCreateTable", "DB2/AIX64",
     ))
   }
 )
+
+## Find temp tables in dbExistsTable and dbListTables on DB2
+
+setMethod("dbExistsTable", c("DB2/AIX64", "Id"),
+  function(conn, name, ...) {
+    tryCatch(expr = {
+      temptables = dbGetQuery(conn, "SELECT TABSCHEMA, TABNAME FROM SYSIBMADM.ADMINTEMPTABLES")
+      # trim whitespace because sometimes schema are saved in the above table with extra whitespace
+      return(any(trimws(temptables$TABNAME) == toupper(id_field(name, "table")) & 
+                   trimws(temptables$TABSCHEMA == toupper(id_field(name, "schema")))) |
+               name@name[["table"]] %in%
+               connection_sql_tables(conn@ptr,
+                                     catalog_name = id_field(name, "catalog"),
+                                     schema_name = id_field(name, "schema"),
+                                     table_name = id_field(name, "table"))
+             )
+      },
+      error = function(cond) {
+        return(name@name[["table"]] %in%
+                 connection_sql_tables(conn@ptr,
+                                       catalog_name = id_field(name, "catalog"),
+                                       schema_name = id_field(name, "schema"),
+                                       table_name = id_field(name, "table"))
+               )
+      }
+    )
+  }
+)
+
+setMethod("dbListTables", "DB2/AIX64",
+  function(conn, ...) {
+    tryCatch(return(c(dbGetQuery("SELECT TABNAME FROM SYSIBMADM.ADMINTEMPTABLES")[["TABNAME"]],
+                      connection_sql_tables(conn@ptr)$table_name)
+                    ),
+             error = function(cond) {
+               return(connection_sql_tables(conn@ptr)$table_name)
+              }
+             )
+  }
+)

--- a/R/db.R
+++ b/R/db.R
@@ -97,10 +97,12 @@ setMethod("sqlCreateTable", "DB2/AIX64",
 setMethod("dbExistsTable", c("DB2/AIX64", "Id"),
   function(conn, name, ...) {
     tryCatch(expr = {
-      temptables = dbGetQuery(conn, "SELECT TABSCHEMA, TABNAME FROM SYSIBMADM.ADMINTEMPTABLES")
+      temptables = dbGetQuery(conn, "SELECT TABSCHEMA, TABNAME, INSTANTIATOR FROM SYSIBMADM.ADMINTEMPTABLES")
       # trim whitespace because sometimes schema are saved in the above table with extra whitespace
       return(any(trimws(temptables$TABNAME) == toupper(id_field(name, "table")) & 
-                   trimws(temptables$TABSCHEMA == toupper(id_field(name, "schema")))) |
+                   trimws(temptables$TABSCHEMA == toupper(id_field(name, "schema"))) &
+                   tolower(trimws(temptables$INSTANTIATOR)) == tolower(conn@info$username)
+                   ) |
                name@name[["table"]] %in%
                connection_sql_tables(conn@ptr,
                                      catalog_name = id_field(name, "catalog"),


### PR DESCRIPTION
DB2 subclass- find temporary tables in dbExistsTable and dbListTables if possible. Defaults to normal behavior.
Thanks to @rnorberg for the suggestion.