### PR TITLE
Updating Snowflake data types

### DIFF
--- a/R/DataTypes.R
+++ b/R/DataTypes.R
@@ -15,6 +15,7 @@
 #' - BigQuery
 #' - Teradata
 #' - Access
+#' - Snowflake
 #'
 #' If you are using a different database and `dbWriteTable()` fails with a SQL
 #' parsing error the default method is not appropriate, you will need to write
@@ -300,16 +301,16 @@ odbcDataType.Oracle <- function(con, obj, ...) {
 `odbcDataType.Snowflake` <- function(con, obj, ...) {
   switch_type(
     obj,
-    factor = "VARCHAR(255)",
+    factor = "VARCHAR",
     datetime = "TIMESTAMP",
     date = "DATE",
     time = "TIME",
-    binary = "VARBINARY(255)",
+    binary = "BINARY",
     integer = "INTEGER",
-    double = "DOUBLE PRECISION",
-    character = "VARCHAR(255)",
+    double = "FLOAT",
+    character = "VARCHAR",
     logical = "BOOLEAN",
-    list = "VARCHAR(255)",
+    list = "VARCHAR",
     stop("Unsupported type", call. = FALSE)
   )
 }

--- a/man/odbcDataType.Rd
+++ b/man/odbcDataType.Rd
@@ -33,6 +33,7 @@ Databases with default methods defined are
 \item BigQuery
 \item Teradata
 \item Access
+\item Snowflake
 }
 }
 \details{


### PR DESCRIPTION
The removes the character constraints on R data types mapped to `VARBINARY` and `VARCHAR` columns  by the `odbcDataType.Snowflake()` function.

Character strings in  both Snowflake and R are not limited to 255 characters. The  documentation for [VARCHAR](https://docs.snowflake.com/en/sql-reference/data-types-text.html#varchar) states: 

> A column consumes storage for only the amount of actual data stored. For example, a 1-character string in a . `VARCHAR(16777216)` column only consumes a single character.
> 
> There is no performance difference between using the full-length `VARCHAR` declaration `VARCHAR(16777216)` or a smaller length.

So there shouldn't be any need for specifying a maximum number of characters in R data types that map to `VARCHAR` and `VARBINARY` data types.

There is one other purely stylistic change, replacing `DOUBLE PRECISION` to the synonym `FLOAT` since the Snowflake docs list `DOUBLE PRECISION` as one of the synonyms of `FLOAT` and not vice-versa.

