### PR TITLE
odbcConnectionColumns: Method ingesting DBI::SQL

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -176,6 +176,23 @@ setMethod(
   }
 )
 
+#' @details odbcConnectionColumns is routed through the SQLColumns ODBC
+#'  method.  This function, together with remaining catalog functions (SQLTables,
+#'  etc), by default ( SQL_ATTR_METADATA_ID == false ) expect either ordinary
+#'  arguments (OA) in the case of the catalog, or pattern value arguments (PV)
+#'  in the case of schema/table name.  For these, quoted identifiers do not make
+#'  sense, so we unquote identifiers prior to the call.
+#' @seealso The ODBC documentation on [Arguments to catalog functions](https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/arguments-in-catalog-functions?view=sql-server-ver16).
+#' @rdname odbcConnectionColumns
+#' @param conn OdbcConnection
+#' @param name table we wish to get information on
+#' @export
+setMethod(
+  "odbcConnectionColumns", c("OdbcConnection", "SQL"),
+  function(conn, name, ...) {
+    odbcConnectionColumns(conn, dbUnquoteIdentifier(conn, name)[[1]], ...)
+  })
+
 # TODO: show encoding, timezone, bigint mapping
 #' @rdname OdbcConnection
 #' @inheritParams methods::show

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -176,16 +176,14 @@ setMethod(
   }
 )
 
-#' @details odbcConnectionColumns is routed through the SQLColumns ODBC
-#'  method.  This function, together with remaining catalog functions (SQLTables,
-#'  etc), by default ( SQL_ATTR_METADATA_ID == false ) expect either ordinary
-#'  arguments (OA) in the case of the catalog, or pattern value arguments (PV)
-#'  in the case of schema/table name.  For these, quoted identifiers do not make
-#'  sense, so we unquote identifiers prior to the call.
+#' @details `odbcConnectionColumns` is routed through the `SQLColumns` ODBC
+#'  method.  This function, together with remaining catalog functions
+#'  (`SQLTables`, etc), by default ( `SQL_ATTR_METADATA_ID == false` ) expect
+#'  either ordinary arguments (OA) in the case of the catalog, or pattern value
+#'  arguments (PV) in the case of schema/table name.  For these, quoted
+#'  identifiers do not make sense, so we unquote identifiers prior to the call.
 #' @seealso The ODBC documentation on [Arguments to catalog functions](https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/arguments-in-catalog-functions?view=sql-server-ver16).
 #' @rdname odbcConnectionColumns
-#' @param conn OdbcConnection
-#' @param name table we wish to get information on
 #' @export
 setMethod(
   "odbcConnectionColumns", c("OdbcConnection", "SQL"),

--- a/R/db.R
+++ b/R/db.R
@@ -91,3 +91,22 @@ setMethod("sqlCreateTable", "DB2/AIX64",
     ))
   }
 )
+
+# Microsoft SQL Server ---------------------------------------------------------
+
+# Simple class prototype to avoid messages about unknown classes from setMethod
+setClass("Microsoft SQL Server", where = class_cache)
+
+# For SQL Server, conn@quote will return the quotation mark, however
+# both quotation marks as well as square bracket are used interchangeably for
+# delimited identifiers.  See:
+# https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver16
+# Therefore strip the brackets first, and then call the DBI method that strips
+# the quotation marks.
+# TODO: the generic implementation in DBI should take a quote char as
+# parameter.
+setMethod("dbUnquoteIdentifier", c("Microsoft SQL Server", "SQL"),
+  function(conn, x, ...) {
+    x <- gsub("(\\[)([^\\.]+?)(\\])", "\\2", x)
+    callNextMethod( conn, x, ... )
+  })

--- a/man/odbcConnectionColumns.Rd
+++ b/man/odbcConnectionColumns.Rd
@@ -67,12 +67,12 @@ to get details on the fields of the table we are writing to.  In particular
 the columns \code{data_type}, \code{column_size}, and \code{decimal_digits} are used.  An
 implementation is not necessary for \code{\link[=dbWriteTable]{dbWriteTable()}} to work.
 
-odbcConnectionColumns is routed through the SQLColumns ODBC
-method.  This function, together with remaining catalog functions (SQLTables,
-etc), by default ( SQL_ATTR_METADATA_ID == false ) expect either ordinary
-arguments (OA) in the case of the catalog, or pattern value arguments (PV)
-in the case of schema/table name.  For these, quoted identifiers do not make
-sense, so we unquote identifiers prior to the call.
+\code{odbcConnectionColumns} is routed through the \code{SQLColumns} ODBC
+method.  This function, together with remaining catalog functions
+(\code{SQLTables}, etc), by default ( \code{SQL_ATTR_METADATA_ID == false} ) expect
+either ordinary arguments (OA) in the case of the catalog, or pattern value
+arguments (PV) in the case of schema/table name.  For these, quoted
+identifiers do not make sense, so we unquote identifiers prior to the call.
 }
 \seealso{
 The ODBC documentation on \href{https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcolumns-function}{SQLColumns}

--- a/man/odbcConnectionColumns.Rd
+++ b/man/odbcConnectionColumns.Rd
@@ -4,6 +4,7 @@
 \alias{odbcConnectionColumns}
 \alias{odbcConnectionColumns,OdbcConnection,Id-method}
 \alias{odbcConnectionColumns,OdbcConnection,character-method}
+\alias{odbcConnectionColumns,OdbcConnection,SQL-method}
 \title{odbcConnectionColumns}
 \usage{
 odbcConnectionColumns(conn, name, ...)
@@ -17,6 +18,8 @@ odbcConnectionColumns(conn, name, ...)
   schema_name = NULL,
   column_name = NULL
 )
+
+\S4method{odbcConnectionColumns}{OdbcConnection,SQL}(conn, name, ...)
 }
 \arguments{
 \item{conn}{OdbcConnection}
@@ -63,8 +66,17 @@ In \code{\link[=dbWriteTable]{dbWriteTable()}} we make a call to this method
 to get details on the fields of the table we are writing to.  In particular
 the columns \code{data_type}, \code{column_size}, and \code{decimal_digits} are used.  An
 implementation is not necessary for \code{\link[=dbWriteTable]{dbWriteTable()}} to work.
+
+odbcConnectionColumns is routed through the SQLColumns ODBC
+method.  This function, together with remaining catalog functions (SQLTables,
+etc), by default ( SQL_ATTR_METADATA_ID == false ) expect either ordinary
+arguments (OA) in the case of the catalog, or pattern value arguments (PV)
+in the case of schema/table name.  For these, quoted identifiers do not make
+sense, so we unquote identifiers prior to the call.
 }
 \seealso{
 The ODBC documentation on \href{https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcolumns-function}{SQLColumns}
 for further details.
+
+The ODBC documentation on \href{https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/arguments-in-catalog-functions?view=sql-server-ver16}{Arguments to catalog functions}.
 }

--- a/tests/testthat/test-SQLServer.R
+++ b/tests/testthat/test-SQLServer.R
@@ -178,6 +178,9 @@ test_that("SQLServer", {
     input <- DBI::SQL(c(
       "testtable",
       "[testtable]",
+      "[\"testtable\"]",
+      "testta[ble",
+      "testta]ble",
       "[testschema].[testtable]",
       "[testschema].testtable",
       "[testdb].[testschema].[testtable]",
@@ -185,6 +188,9 @@ test_that("SQLServer", {
     expected <- c(
       DBI::Id( table = "testtable" ),
       DBI::Id( table = "testtable" ),
+      DBI::Id( table = "testtable" ),
+      DBI::Id( table = "testta[ble" ),
+      DBI::Id( table = "testta]ble" ),
       DBI::Id( schema = "testschema", table = "testtable" ),
       DBI::Id( schema = "testschema", table = "testtable" ),
       DBI::Id( catalog = "testdb", schema = "testschema", table = "testtable" ),

--- a/tests/testthat/test-SQLServer.R
+++ b/tests/testthat/test-SQLServer.R
@@ -186,16 +186,16 @@ test_that("SQLServer", {
       "[testdb].[testschema].[testtable]",
       "[testdb].[testschema].testtable" ))
     expected <- c(
-      DBI::Id( table = "testtable" ),
-      DBI::Id( table = "testtable" ),
-      DBI::Id( table = "testtable" ),
-      DBI::Id( table = "testta[ble" ),
-      DBI::Id( table = "testta]ble" ),
-      DBI::Id( schema = "testschema", table = "testtable" ),
-      DBI::Id( schema = "testschema", table = "testtable" ),
-      DBI::Id( catalog = "testdb", schema = "testschema", table = "testtable" ),
-      DBI::Id( catalog = "testdb", schema = "testschema", table = "testtable" ) )
-    expect_identical( DBI::dbUnquoteIdentifier( con, input ), expected )
+      DBI::Id(table = "testtable"),
+      DBI::Id(table = "testtable"),
+      DBI::Id(table = "testtable"),
+      DBI::Id(table = "testta[ble"),
+      DBI::Id(table = "testta]ble"),
+      DBI::Id(schema = "testschema", table = "testtable"),
+      DBI::Id(schema = "testschema", table = "testtable"),
+      DBI::Id(catalog = "testdb", schema = "testschema", table = "testtable"),
+      DBI::Id(catalog = "testdb", schema = "testschema", table = "testtable"))
+    expect_identical(DBI::dbUnquoteIdentifier(con, input), expected)
 
   })
 

--- a/tests/testthat/test-SQLServer.R
+++ b/tests/testthat/test-SQLServer.R
@@ -173,6 +173,26 @@ test_that("SQLServer", {
     expect_equal(as.double(values[[6]]), as.double(received[[6]]))
   })
 
+  local({
+    con <- DBItest:::connect(DBItest:::get_default_context())
+    input <- DBI::SQL(c(
+               "testtable",
+               "[testtable]",
+               "[testschema].[testtable]",
+               "[testschema].testtable",
+               "[testdb].[testschema].[testtable]",
+               "[testdb].[testschema].testtable" ))
+    expected <- c(
+                  DBI::Id( table = "testtable" ),
+                  DBI::Id( table = "testtable" ),
+                  DBI::Id( schema = "testschema", table = "testtable" ),
+                  DBI::Id( schema = "testschema", table = "testtable" ),
+                  DBI::Id( catalog = "testdb", schema = "testschema", table = "testtable" ),
+                  DBI::Id( catalog = "testdb", schema = "testschema", table = "testtable" ) )
+    expect_identical( DBI::dbUnquoteIdentifier( con, input ), expected )
+
+  })
+
   test_that("dates should always be interpreted in the system time zone (#398)", {
     con <- DBItest:::connect(DBItest:::get_default_context(), timezone = "America/Chicago")
     res <- dbGetQuery(con, "SELECT CAST(? AS date)", params = as.Date("2019-01-01"))

--- a/tests/testthat/test-SQLServer.R
+++ b/tests/testthat/test-SQLServer.R
@@ -176,19 +176,19 @@ test_that("SQLServer", {
   local({
     con <- DBItest:::connect(DBItest:::get_default_context())
     input <- DBI::SQL(c(
-               "testtable",
-               "[testtable]",
-               "[testschema].[testtable]",
-               "[testschema].testtable",
-               "[testdb].[testschema].[testtable]",
-               "[testdb].[testschema].testtable" ))
+      "testtable",
+      "[testtable]",
+      "[testschema].[testtable]",
+      "[testschema].testtable",
+      "[testdb].[testschema].[testtable]",
+      "[testdb].[testschema].testtable" ))
     expected <- c(
-                  DBI::Id( table = "testtable" ),
-                  DBI::Id( table = "testtable" ),
-                  DBI::Id( schema = "testschema", table = "testtable" ),
-                  DBI::Id( schema = "testschema", table = "testtable" ),
-                  DBI::Id( catalog = "testdb", schema = "testschema", table = "testtable" ),
-                  DBI::Id( catalog = "testdb", schema = "testschema", table = "testtable" ) )
+      DBI::Id( table = "testtable" ),
+      DBI::Id( table = "testtable" ),
+      DBI::Id( schema = "testschema", table = "testtable" ),
+      DBI::Id( schema = "testschema", table = "testtable" ),
+      DBI::Id( catalog = "testdb", schema = "testschema", table = "testtable" ),
+      DBI::Id( catalog = "testdb", schema = "testschema", table = "testtable" ) )
     expect_identical( DBI::dbUnquoteIdentifier( con, input ), expected )
 
   })


### PR DESCRIPTION
This closes https://github.com/r-dbi/odbc/issues/458

Adds a method to `odbc::odbcConnectionColumns` that ingests `DBI::SQL`.

Currently, in addition to exposing the method so that users can inspect table structure, we use `odbcConnectionsColumns` when writing to tables to work around a deficiency in the `FreeTDS` implementation of the ODBC API for SQL Server.

Similar to, for example, `dbExistsTable`, here too we unquote the identifier before passing it to the ODBC API.  This is necessary for catalog functions that are part of the ODBC API ( like `SQLTables`, `SQLColumns` etc).

Thanks