### PR TITLE
tests: drivers: skip if no data sources

### DIFF
--- a/tests/testthat/test-drivers.R
+++ b/tests/testthat/test-drivers.R
@@ -26,6 +26,9 @@ test_that("odbcListDataSources() returns available data sources", {
   skip_if_no_drivers()
 
   res <- odbcListDataSources()
+  if (nrow(res) == 0) {
+    skip("No odbc data-sources configured")
+  }
   expect_identical(names(res), c("name", "description"))
   expect_true(nrow(res) >= 1)
 })


### PR DESCRIPTION
Fixup unit tests in CI.

Looks like there may be one outstanding warning from coming from `sprintf` being used in a header included from Rcpp.  FWICT, this is fixed on github; probably see it as part of Rcpp's January CRAN release.