### PR TITLE
ci: db: Update ubuntu packagemanager repo

### DIFF
--- a/.github/workflows/db.yaml
+++ b/.github/workflows/db.yaml
@@ -44,7 +44,7 @@ jobs:
           - SQLite
 
     env:
-      CRAN: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"
+      CRAN: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
       ODBCSYSINI: ${{ github.workspace }}/.github/odbc
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Should cut down the runtime for this workflow from ~10m to ~6m.

![Screenshot 2023-01-28 at 11 26 17 AM](https://user-images.githubusercontent.com/1133993/215277682-8ad3b790-da50-4630-aa19-49e1e9d896ed.png)

