### PR TITLE
try deallocate(); in ~connection_impl() NANODBC_NOEXCEPT

### DIFF
--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -902,7 +902,14 @@ public:
         {
             // ignore exceptions thrown during disconnect
         }
-        deallocate();
+        try
+        {
+             deallocate();
+        }
+        catch (...)
+        {
+            // ignore exceptions thrown during disconnect
+        }
     }
 
     void allocate()


### PR DESCRIPTION
the deallocate() throws an error in case of an error in disconnect(), but it is not protected by a try. fix #539 