### PR TITLE
CI: Build mysql connector

### DIFF
--- a/.github/odbc/install-mariadb-driver.sh
+++ b/.github/odbc/install-mariadb-driver.sh
@@ -1,16 +1,9 @@
-# from https://mariadb.com/kb/en/about-mariadb-connector-odbc/#installing-mariadb-connectorodbc-on-debianubuntu
-mkdir odbc_package
-pushd odbc_package
-wget https://downloads.mariadb.com/Connectors/odbc/connector-odbc-3.1.7/mariadb-connector-odbc-3.1.7-ga-debian-x86_64.tar.gz
-tar -xvzf mariadb-connector-odbc-3.1.7-ga-debian-x86_64.tar.gz
-sudo install lib/libmaodbc.so /usr/lib/
-sudo install -d /usr/lib/mariadb/
-sudo install -d /usr/lib/mariadb/plugin/
-sudo install lib/mariadb/plugin/auth_gssapi_client.so /usr/lib/mariadb/plugin/
-sudo install lib/mariadb/plugin/caching_sha2_password.so /usr/lib/mariadb/plugin/
-sudo install lib/mariadb/plugin/client_ed25519.so /usr/lib/mariadb/plugin/
-sudo install lib/mariadb/plugin/dialog.so /usr/lib/mariadb/plugin/
-sudo install lib/mariadb/plugin/mysql_clear_password.so /usr/lib/mariadb/plugin/
-sudo install lib/mariadb/plugin/sha256_password.so /usr/lib/mariadb/plugin/
-popd
-rm -r odbc_package
+sudo apt-get install -y cmake
+cd /tmp && git clone https://github.com/MariaDB/mariadb-connector-odbc.git connector
+cd connector && git checkout 3.1.17
+mkdir build && cd build
+cmake ../ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_SSL=OPENSSL
+cmake --build . --config RelWithDebInfo
+sudo make install
+sudo ln -s /usr/local/lib/mariadb/libmariadb.so.3 /usr/local/lib/
+sudo ldconfig

--- a/.github/odbc/odbcinst.ini
+++ b/.github/odbc/odbcinst.ini
@@ -7,7 +7,7 @@ FileUsage=1
 Threading=2
 
 [MySQL Driver]
-Driver=/usr/lib/libmaodbc.so
+Driver=/usr/local/lib/mariadb/libmaodbc.so
 UsageCount = 1
 Threading=2
 


### PR DESCRIPTION
Closes #547 

The ODBC MariaDB/Connector pre-built binaries are no longer a good match for recent Ubuntu builds.

In lieu of bringing in the binaries, we build the connector.  MySQL tests should be running now. 