### PR TITLE
CI: Add DB unit testing on a Window host

### DIFF
--- a/.github/workflows/db-windows.yml
+++ b/.github/workflows/db-windows.yml
@@ -1,0 +1,108 @@
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+
+name: DBs (Windows)
+
+jobs:
+  testthat-Windows:
+    runs-on: windows-latest
+    name: ${{ matrix.database }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
+          - SQLServer
+          - MySQL
+          - PostgreSQL
+          - SQLite
+    env:
+      CRAN: "https://packagemanager.rstudio.com/cran/latest"
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - name: Install SQL Server
+        if: matrix.database == 'SQLServer'
+        uses: potatoqualitee/mssqlsuite@v1.7
+        with:
+          install: sqlengine, sqlclient
+          version: 2019
+          sa-password: Password12
+          show-log: true
+
+      - name: Install MySQL
+        if: matrix.database == 'MySQL'
+        uses: ankane/setup-mysql@v1
+        with:
+          database: test
+
+      - name: Install PostgreSQL
+        if: matrix.database == 'PostgreSQL'
+        uses: ankane/setup-postgres@v1
+        with:
+          database: test
+
+      - name: Install SQLite
+        if: matrix.database == 'SQLite'
+        run: |
+          (New-Object Net.WebClient).DownloadFile('http://www.ch-werner.de/sqliteodbc/sqliteodbc_w64.exe', 'sqliteodbc_w64.exe')
+           ./sqliteodbc_w64.exe /S
+
+      - name: Install Driver Support
+        if: matrix.database == 'SQLServer'
+        run: |
+          echo "ODBC_CS=Driver={ODBC Driver 17 for SQL Server};Server=localhost;Uid=sa;Pwd=Password12" >> $env:GITHUB_ENV
+
+      - name: Install Driver Support
+        if: matrix.database == 'MySQL'
+        run: |
+          choco install mysql-odbc
+          echo "ODBC_CS=Driver={MySQL ODBC 5.3 ANSI Driver};Server=127.0.0.1;Database=test;User=root;Password=" >> $env:GITHUB_ENV
+
+      - name: Install Driver Support
+        if: matrix.database == 'PostgreSQL'
+        run: |
+          choco install psqlodbc
+          echo "ODBC_CS=Driver={PostgreSQL ANSI(x64)};Server=localhost;Port=5432;BoolsAsChar=0;LFConversion=0;Database=test;UID=postgres;PWD=" >> $env:GITHUB_ENV
+
+      - name: Install Driver Support
+        if: matrix.database == 'SQLite'
+        run: |
+          echo "ODBC_CS=Driver={SQLite3 ODBC Driver};Database=${{ runner.temp }}\test;Timeout=2000" >> $env:GITHUB_ENV
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: r-dbi/DBITest
+          needs: check
+
+      - name: Install locally to avoid error with test_local()
+        run: |
+          install.packages(".", repos = NULL, type = "source")
+        shell: Rscript {0}
+
+      - name: Test0
+        run: |
+          library(odbc); odbc::odbcListDrivers(); odbc::odbcListDataSources();
+        shell: Rscript {0}
+
+      - name: Test1
+        run: |
+          Sys.getenv("ODBC_CS");
+        shell: Rscript {0}
+
+      - name: Test
+        run: |
+          testthat::test_local(filter = "${{ matrix.database }}", reporter = testthat::ProgressReporter$new(max_failures = Inf, update_interval = Inf))
+        shell: Rscript {0}

--- a/.github/workflows/db.yaml
+++ b/.github/workflows/db.yaml
@@ -8,7 +8,7 @@ on:
       - master
       - main
 
-name: DBs
+name: DBs (Linux)
 
 jobs:
   testthat:
@@ -63,32 +63,36 @@ jobs:
           sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
           sudo -s eval "$sysreqs"
 
-      - name: Setup MySQL
+      - name: Install MySQL Driver
         if: matrix.database == 'MySQL'
         run: |
           sudo systemctl start mysql.service
           mysql -uroot -h127.0.0.1 -proot -e 'CREATE DATABASE `test`;'
           .github/odbc/install-mariadb-driver.sh
+          echo "ODBC_CS=dsn=MySQL" >> $GITHUB_ENV
 
       - name: Install SQLite Driver
         if: matrix.database == 'SQLite'
         run: |
           sudo apt-get install -y libsqliteodbc
+          echo "ODBC_CS=dsn=SQLite" >> $GITHUB_ENV
 
       - name: Install PostgreSQL Driver
         if: matrix.database == 'PostgreSQL'
         run: |
           sudo apt-get install -y unixodbc-dev odbc-postgresql devscripts
+          echo "ODBC_CS=dsn=PostgreSQL" >> $GITHUB_ENV
 
       - name: Install SQL Server Driver
         if: matrix.database == 'SQLServer'
         run: |
-          curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-          curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
-          apt-get update
-          ACCEPT_EULA=Y apt-get install -y msodbcsql17
-          ln -s /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.*.so.* /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.so
-        shell: sudo bash {0}
+          echo "ODBC_CS=dsn=MicrosoftSQLServer;UID=SA;PWD=Password12" >> $GITHUB_ENV
+          sudo bash -c "
+            curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+            && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+            && apt-get update \
+            && ACCEPT_EULA=Y apt-get install -y msodbcsql17 \
+            && ln -s /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.*.so.* /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.so"
 
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/tests/testthat/test-MySQL.R
+++ b/tests/testthat/test-MySQL.R
@@ -1,6 +1,7 @@
 test_that("MySQL", {
   skip_unless_has_test_db({
-    DBItest::make_context(odbc(), list(dsn = "MySQL"), tweaks = DBItest::tweaks(temporary_tables = FALSE), name = "MySQL")
+    DBItest::make_context(odbc(), list(.connection_string = Sys.getenv("ODBC_CS")),
+      tweaks = DBItest::tweaks(temporary_tables = FALSE), name = "MySQL")
   })
 
   DBItest::test_getting_started(c(

--- a/tests/testthat/test-PostgreSQL.R
+++ b/tests/testthat/test-PostgreSQL.R
@@ -1,12 +1,13 @@
 test_that("PostgreSQL", {
   skip_unless_has_test_db({
-    DBItest::make_context(odbc(), list(dsn = "PostgreSQL"), tweaks = DBItest::tweaks(temporary_tables = FALSE, placeholder_pattern = "?"), name = "PostgreSQL")
+    DBItest::make_context(odbc(), list(.connection_string = Sys.getenv("ODBC_CS")),
+      tweaks = DBItest::tweaks(temporary_tables = FALSE, placeholder_pattern = "?"), name = "PostgreSQL")
   })
 
   context("custom tests")
   test_that("show method works as expected with real connection", {
     skip_on_os("windows")
-    con <- dbConnect(odbc(), "PostgreSQL")
+    con <- DBItest:::connect(DBItest:::get_default_context())
 
     expect_output(show(con), "@localhost")
     expect_output(show(con), "Database: [a-z]+")
@@ -14,11 +15,15 @@ test_that("PostgreSQL", {
   })
 
   test_that("64 bit integers work with alternate mappings", {
-    con_default <- dbConnect(odbc(), "PostgreSQL")
-    con_integer64 <- dbConnect(odbc(), "PostgreSQL", bigint = "integer64")
-    con_integer <- dbConnect(odbc(), "PostgreSQL", bigint = "integer")
-    con_numeric <- dbConnect(odbc(), "PostgreSQL", bigint = "numeric")
-    con_character <- dbConnect(odbc(), "PostgreSQL", bigint = "character")
+    con_default <- DBItest:::connect(DBItest:::get_default_context())
+    con_integer64 <-
+      DBItest:::connect(DBItest:::get_default_context(), bigint = "integer64")
+    con_integer <-
+      DBItest:::connect(DBItest:::get_default_context(), bigint = "integer")
+    con_numeric <-
+      DBItest:::connect(DBItest:::get_default_context(), bigint = "numeric")
+    con_character <-
+      DBItest:::connect(DBItest:::get_default_context(), bigint = "character")
 
     dbWriteTable(con_default, "test", data.frame(a = 1:10L), field.types = c(a = "BIGINT"))
     on.exit(dbRemoveTable(con_default, "test"))
@@ -40,7 +45,7 @@ test_that("PostgreSQL", {
   # differently than the table we are targetting.
   test_that("Writing data.frame with column ordering different than target table", {
     tblName <- "test_order_write"
-    con <- dbConnect(odbc(), "PostgreSQL")
+    con <- DBItest:::connect(DBItest:::get_default_context())
     values <- data.frame(
       datetime = as.POSIXct(c(14, 15), origin = "2016-01-01", tz = "UTC"),
       name = c("one", "two"),

--- a/tests/testthat/test-SQLServer.R
+++ b/tests/testthat/test-SQLServer.R
@@ -1,6 +1,7 @@
 test_that("SQLServer", {
   skip_unless_has_test_db({
-      DBItest::make_context(odbc(), list(dsn = "MicrosoftSQLServer", UID="SA", PWD="Password12"), tweaks = DBItest::tweaks(temporary_tables = FALSE), name = "SQLServer")
+    DBItest::make_context(odbc(), list(.connection_string = Sys.getenv("ODBC_CS")),
+      tweaks = DBItest::tweaks(temporary_tables = FALSE), name = "SQLServer")
   })
 
   DBItest::test_getting_started(c(

--- a/tests/testthat/test-SQLite.R
+++ b/tests/testthat/test-SQLite.R
@@ -1,6 +1,7 @@
 test_that("SQLite", {
   skip_unless_has_test_db({
-    ctx <- DBItest::make_context(odbc(), list(dsn = "SQLite"), tweaks = DBItest::tweaks(placeholder_pattern = "?", strict_identifier = TRUE), name = "SQLite")
+    DBItest::make_context(odbc(), list(.connection_string = Sys.getenv("ODBC_CS")),
+      tweaks = DBItest::tweaks(placeholder_pattern = "?", strict_identifier = TRUE), name = "SQLite")
   })
 
   DBItest::test_getting_started(c(


### PR DESCRIPTION
This adds a workflow for DB unit tests ( SQL Server, PostgreSQL, MySQL, SQLite ) on a "windows-latest" host, to complement the existing unit tests that run on Ubuntu.

Considered matrix-ing out the existing Linux DB workflow.  In the end I thought this looked a bit cleaner, at the cost of some step repetition.