### PR TITLE
Permit retrieval of unicode data in VAR/CHAR columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # odbc (development version)
 
+* Fixed truncation when retrieving unicode data stored in
+  VAR/CHAR columns (@detule, #553).
 * MYSQL: Fixed retrieving results from stored procedures (@detule, #435).
 * Fixed issue related to fetching zero rows (@detule, #528).
 

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -17,7 +17,7 @@ cctz/libcctz.a:
 $(MAKE) libcctz.a CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS)" AR="$(AR)" ARFLAGS=$(ARFLAGS) CXXPICFLAGS="$(CXXPICFLAGS)")
 
 nanodbc.o: nanodbc/nanodbc.cpp
-	$(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) -c $< -o $@
+	$(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) -DNANODBC_OVERALLOCATE_CHAR -c $< -o $@
 
 clean:
 	(cd cctz; $(MAKE) clean)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -14,7 +14,7 @@ cctz/libcctz.a:
 $(MAKE) libcctz.a PREFIX="../" CC="$(CC)" CXX="$(CXX)" AR="$(AR)" ARFLAGS=$(ARFLAGS))
 
 nanodbc.o: nanodbc/nanodbc.cpp
-	$(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) -c $< -o $@
+	$(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) -DNANODBC_OVERALLOCATE_CHAR -c $< -o $@
 
 clean:
 	(cd cctz; $(MAKE) clean)

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -102,6 +102,16 @@
 #endif
 #endif
 
+#if defined(NANODBC_OVERALLOCATE_CHAR)
+// If enabled, when auto-binding buffers to N/VAR/CHAR
+// columns, overallocate assuming each code-point
+// takes up MAX_CODE_POINT_SIZE bytes
+#define MAX_CODE_POINT_SIZE 4
+#define NBYTES(nchars, chartype) (nchars + 1) * MAX_CODE_POINT_SIZE
+#else
+#define NBYTES(nchars, chartype) (nchars + 1) * sizeof(chartype)
+#endif
+
 // clang-format off
 // 888     888          d8b                       888
 // 888     888          Y8P                       888
@@ -2839,24 +2849,6 @@ private:
             if (!success(rc))
                 NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
 
-            // Adjust the sqlsize parameter in case of "unlimited" data (varchar(max),
-            // nvarchar(max)).
-            bool is_blob = false;
-
-            if (sqlsize == 0)
-            {
-                switch (sqltype)
-                {
-                case SQL_VARCHAR:
-                case SQL_WVARCHAR:
-                {
-                    // Divide in half, due to sqlsize being 32-bit in Win32 (and 64-bit in x64)
-                    // sqlsize = std::numeric_limits<int32_t>::max() / 2 - 1;
-                    is_blob = true;
-                }
-                }
-            }
-
             bound_column& col = bound_columns_[i];
             col.name_ = reinterpret_cast<string_type::value_type*>(column_name);
             col.column_ = i;
@@ -2903,8 +2895,8 @@ private:
             case SQL_CHAR:
             case SQL_VARCHAR:
                 col.ctype_ = SQL_C_CHAR;
-                col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLCHAR);
-                if (is_blob)
+                col.clen_ = NBYTES(col.sqlsize_, SQLCHAR);
+                if (col.sqlsize_ == 0)
                 {
                     col.clen_ = 0;
                     col.blob_ = true;
@@ -2912,14 +2904,17 @@ private:
                 break;
             case SQL_WCHAR:
             case SQL_WVARCHAR:
-            case SQL_SS_TIMESTAMPOFFSET:
                 col.ctype_ = SQL_C_WCHAR;
-                col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);
-                if (is_blob)
+                col.clen_ = NBYTES(col.sqlsize_, SQLWCHAR);
+                if (col.sqlsize_ == 0)
                 {
                     col.clen_ = 0;
                     col.blob_ = true;
                 }
+                break;
+            case SQL_SS_TIMESTAMPOFFSET:
+                col.ctype_ = SQL_C_WCHAR;
+                col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);
                 break;
             case SQL_LONGVARCHAR:
                 col.ctype_ = SQL_C_CHAR;

--- a/tests/testthat/test-SQLServer.R
+++ b/tests/testthat/test-SQLServer.R
@@ -217,6 +217,14 @@ test_that("SQLServer", {
     expect_equal(res[[1]], as.Date("2019-01-01"))
   })
 
+  test_that("UTF in VARCHAR is not truncated", {
+    con <- DBItest:::connect(DBItest:::get_default_context())
+    value <- "grün"
+    res <- dbGetQuery(con,
+      paste0("SELECT '", value, "' AS colone"))
+    expect_equal(value, res[[1]])
+  })
+
   test_that("Zero-row-fetch does not move cursor", {
     con <- DBItest:::connect(DBItest:::get_default_context())
     tblName <- "test_zero_row_fetch"


### PR DESCRIPTION
This fixes #369 #437 #489 #524

There are some more details about the issue [here](https://github.com/r-dbi/odbc/issues/489#issuecomment-1457363582)

The short summary is:  This work helps us better support

- Some unorthodox use-patterns: unicode data in VAR/CHAR columns.
- Back-ends where character data types are synonymous ( Snowflake ).

This comes at the cost of larger memory allocations.  However these memory allocations are transient ( created/destroyed with each query ), and do not scale, for example, with the size of the data set ( number of rows ).  From that perspective, I expect marginal impact - but worth keeping an eye out.