### PR TITLE
Changing data type for datetimes from "DATE" to "TIMESTAMP" for Spark.

### DIFF
--- a/R/DataTypes.R
+++ b/R/DataTypes.R
@@ -92,7 +92,7 @@ odbcDataType.default <- function(con, obj, ...) {
 `odbcDataType.Spark SQL` <- function(con, obj, ...) {
   switch_type(obj,
     factor = "VARCHAR(255)",
-    datetime = "DATE",
+    datetime = "TIMESTAMP",
     date = "DATE",
     binary = "BINARY",
     integer = "INT",


### PR DESCRIPTION
Fixes https://github.com/r-dbi/odbc/issues/555