### PR TITLE
class_cache: Parented by package env

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -31,7 +31,7 @@ SUPPORTED_CONNECTION_ATTRIBUTES <-
 #' @name OdbcConnection
 NULL
 
-class_cache <- new.env(parent = emptyenv())
+class_cache <- new.env()
 
 OdbcConnection <- function(
   dsn = NULL,


### PR DESCRIPTION
Hi @hadley:

I think this fixes https://github.com/r-dbi/odbc/issues/558

To be perfectly honest, main motivation here is not necessarily to fix, but to protect against what looks to be the issue there ( clobbering S4 object definitions ).  I suspect that the [`new` call ](https://github.com/r-dbi/odbc/blob/main/R/Connection.R#L84)picks up another definition of, for example, `Microsoft SQL Server`.

As best as I can tell there is no downside to having package environment be the parent of the class cache: [`getClassDef`](https://github.com/r-dbi/odbc/blob/main/R/Connection.R#L79) is called with `inherits=FALSE` which I think prevents lookup outside of the specified environment ( enclosing environments etc ).

The upside is that the subsequent `new` call should prefer the odbc S4 definitions over other in the global environment that someone else may have defined.

There are other ways to address this, I think.  I thought about for example, evaluating the `new` call in the `class_cache` environment.  This also works but one needs to do some yoga to ensure `package::methods` is found in the environment as well.

How I tested:
```
> library(odbc)
> conn <- dbConnect(odbc::odbc(), dsn = "mssql_oem_db")
> setClass("Microsoft SQL Server", slots = list(name = 'character'))
> conn <- dbConnect(odbc::odbc(), dsn = "mssql_oem_db")
Error in initialize(value, ...) :
  invalid names for slots of class “Microsoft SQL Server”: ptr, quote, info, encoding
```
