### PR TITLE
dbExistsTable: Specialize for oracle

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -337,17 +337,6 @@ setMethod(
       table_type = table_type)$table_name
   })
 
-#' @rdname OdbcConnection
-#' @inheritParams DBI::dbExistsTable
-#' @export
-setMethod(
-  "dbExistsTable", c("OdbcConnection", "character"),
-  function(conn, name, ...) {
-    stopifnot(length(name) == 1)
-    df <- connection_sql_tables(conn@ptr, table_name = name)
-    NROW(df) > 0
-  })
-
 #' @inherit DBI::dbListFields
 #' @inheritParams DBI::dbListFields
 #' @aliases dbListFields

--- a/R/Table.R
+++ b/R/Table.R
@@ -218,6 +218,18 @@ setMethod(
 #' @inheritParams DBI::dbExistsTable
 #' @export
 setMethod(
+  "dbExistsTable", c("OdbcConnection", "character"),
+  function(conn, name, ...) {
+    stopifnot(length(name) == 1)
+    df <- connection_sql_tables(conn@ptr, table_name = name)
+    NROW(df) > 0
+  })
+
+
+#' @rdname OdbcConnection
+#' @inheritParams DBI::dbExistsTable
+#' @export
+setMethod(
   "dbExistsTable", c("OdbcConnection", "SQL"),
   function(conn, name, ...) {
     dbExistsTable(conn, dbUnquoteIdentifier(conn, name)[[1]], ...)


### PR DESCRIPTION
Hi:

This should improve `dbWriteTable` performance when writing to an `Oracle` connection.  ( See: https://github.com/r-dbi/odbc/issues/540 )

Notes:
* Ideally would have liked to insert this query based approach for Oracle in `dbListTables`.  However, for `dbListTables("OdbcConnection"`, we advertise pattern based argument matching which is specific to the `SQLTables`/`connection_sql_tables` API; can bend the query to also do something similar but it's a bit more involved so punted for now.
* Outstanding are connection pane performance issues for `Oracle` which are also related to usage of `connection_sql_tables`.  Have an idea how to mitigate at least some of them ( listing catalogs, schemas, etc ).  Will address subsequently.
* Also in this PR, moved one of the specializations of `dbExistsTable` from `Connection.R` to `Table.R`, together with the remaining specializations. 