### PR TITLE
nanodbc: include cstdint unconditionally

### DIFF
--- a/src/nanodbc/nanodbc.h
+++ b/src/nanodbc/nanodbc.h
@@ -84,9 +84,7 @@
 #include <string>
 #include <vector>
 
-#ifndef __clang__
 #include <cstdint>
-#endif
 
 /// \brief The entirety of nanodbc can be found within this one namespace.
 ///


### PR DESCRIPTION
Fixes reported issue when building with clang16:

```
nanodbc/nanodbc.h:301:5: error: no type named 'int16_t' in namespace 'std'; did you mean simply 'int16_t'?
```

Originally authored by Kurt Hornik.