### PR TITLE
maintenance: Remove C++11 from system requirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Config/Needs/check:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-SystemRequirements: C++11, GNU make, An ODBC3 driver manager and drivers.
+SystemRequirements: GNU make, An ODBC3 driver manager and drivers.
 Collate: 
     'odbc.R'
     'Driver.R'


### PR DESCRIPTION
Some resources:

* [WRE ](https://cran.r-project.org/doc/manuals/R-exts.html#Using-C_002b_002b-code)on the topic.
* Winston's excellent [writeup](https://gist.github.com/wch/849ca79c9416795d99c48cc06a44ca1e).

Apparently [we don't specify](https://github.com/r-dbi/odbc/commit/5d85c20b8bb815e54a89db06ed2267f767eb43d5) ```CXX_STD``` in our Makevars (nor do we, as best as I can tell, in our `configure` script). I am a bit on the fence whether to do so now that we no longer have the standard specified under `SystemRequirements`.  Going with WRE on this one:

```On the other hand, specifying C++11[48](https://cran.r-project.org/doc/manuals/R-exts.html#FOOT48) when the code is valid under C++14 or C++17 reduces future portability.```