### PR TITLE
nanodbc: remove assert

### DIFF
--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -3421,7 +3421,6 @@ std::unique_ptr<T, std::function<void(T*)>> result::result_impl::ensure_pdata(sh
         col.cbdata_[static_cast<size_t>(rowset_position_)] = (SQLINTEGER)SQL_NULL_DATA;
     if (!success(rc))
         NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
-    NANODBC_ASSERT(ValueLenOrInd == (SQLLEN)buffer_size);
 
     // Return a traditional unique_ptr since we just allocated this buffer, and
     // we most certainly want this memory returned to the heap when the result


### PR DESCRIPTION
Hi:

This fixes [604](https://github.com/r-dbi/odbc/issues/604).

Discovered by running the failing code under gdb.  Saw
```
#4  0x00007fbddd0863a2 in __assert_fail () from /lib/x86_64-linux-gnu/libc.so.6
#5  0x00007fbcca924924 in nanodbc::result::result_impl::ensure_pdata<long> (this=0x55a7811c80a0, column=1) at nanodbc/nanodbc.cpp:3424
#6  0x00007fbcca93677d in nanodbc::result::result_impl::get_ref_impl<int> (this=0x55a7811c80a0, column=1, result=@0x7ffe1c586d14: 0) at nanodbc/nanodbc.cpp:3464
```

Similar to upstream [a94cb6a3d236a4b5103442edf7e2b718c3660dde](https://github.com/nanodbc/nanodbc/commit/a94cb6a3d236a4b5103442edf7e2b718c3660dde)