### PR TITLE
don't assign `dbWriteTable()` output

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -282,7 +282,7 @@ data <- dbReadTable(con, "flights")
 ### Writing
 `dbWriteTable()` will write an R `data.frame()` to an SQL table.
 ```r
-data <- dbWriteTable(con, "iris", iris)
+dbWriteTable(con, "iris", iris)
 ```
 
 ### Querying

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ data <- dbReadTable(con, "flights")
 `dbWriteTable()` will write an R `data.frame()` to an SQL table.
 
 ``` r
-data <- dbWriteTable(con, "iris", iris)
+dbWriteTable(con, "iris", iris)
 ```
 
 ### Querying


### PR DESCRIPTION
The object name `data` is misleading given that `dbWriteTable()` always returns`TRUE` invisibly.