### PR TITLE
workshop docs for `odbcListDrivers()` and `odbcListDataSources()`

### DIFF
--- a/man/odbcListDataSources.Rd
+++ b/man/odbcListDataSources.Rd
@@ -7,14 +7,88 @@
 odbcListDataSources()
 }
 \value{
-A data frame with two columns.
+A data frame with two columns:
 \describe{
-\item{name}{Name of the data source}
-\item{description}{Data Source description}
+\item{name}{Name of the data source. The entries in this column can be
+passed to the \code{dsn} argument of \code{\link[=dbConnect]{dbConnect()}}.}
+\item{description}{Data source description.}
 }
 }
 \description{
-List the available data sources on your system. See the \href{https://github.com/r-dbi/odbc#dsn-configuration-files}{DSN Configuration files} section of the
-package README for details on how to install data sources for the most
-common databases.
+Collect information about the available data source names (DSNs).
+}
+\section{Configuration}{
+
+
+This function interfaces with the driver manager to collect information
+about the available data source names.
+
+For \strong{MacOS and Linux}, the odbc package supports the unixODBC driver
+manager. unixODBC looks to the \code{odbc.ini} \emph{configuration file} for information
+on DSNs. Install unixODBC with \verb{brew install unixodbc}, and find the
+location(s) of your \code{odbc.ini} file(s) with \code{odbcinst -j}.
+
+In this example \code{odbc.ini} file:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{[MySQL]
+Driver = MySQL Driver
+Database = test
+Server = 127.0.0.1
+User = root
+password = root
+Port = 3306
+}\if{html}{\out{</div>}}
+
+...the data source name is \code{MySQL}, which will appear in the \code{name}
+column of this function's output. To pass the DSN as the \code{dsn} argument to
+\code{\link[=dbConnect]{dbConnect()}}, pass it as a string, like \code{"MySQL"}.
+\verb{Driver = MySQL Driver} references the driver \code{name} in \code{\link[=odbcListDrivers]{odbcListDrivers()}}
+output.
+
+\strong{Windows} is \href{https://learn.microsoft.com/en-us/sql/odbc/admin/odbc-data-source-administrator}{bundled}
+with an ODBC driver manager.
+
+When a DSN is configured with a driver manager, information on the DSN will
+be automatically passed on to \code{\link[=dbConnect]{dbConnect()}} when its \code{dsn} argument is set.
+
+For example, with the \code{MySQL} data source name configured, and the driver
+name \verb{MySQL Driver} appearing in \code{\link[=odbcListDrivers]{odbcListDrivers()}} output, the code:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{con <-
+  dbConnect(
+    odbc::odbc(),
+    "MySQL",
+    Driver = "MySQL Driver",
+    Database = "test",
+    Server = "127.0.0.1",
+    User = "root",
+    password = "root",
+    Port = 3306
+  )
+}\if{html}{\out{</div>}}
+
+...can be written:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{con <- dbConnect(odbc::odbc(), "MySQL")
+}\if{html}{\out{</div>}}
+}
+
+\section{Learn more}{
+
+
+To learn more about databases:
+\itemize{
+\item \href{https://solutions.posit.co/connections/db/}{"Best Practices in Working with Databases"}
+documents how to use the odbc package with various popular databases.
+\item \href{https://github.com/mkleehammer/pyodbc/wiki/Drivers-and-Driver-Managers}{The pyodbc "Drivers and Driver Managers" Wiki}
+provides further context on drivers and driver managers.
+\item \href{https://learn.microsoft.com/en-us/sql/odbc/reference}{Microsoft's "Introduction to ODBC"}
+is a thorough resource on the ODBC interface.
+}
+}
+
+\seealso{
+\code{\link[=odbcListDrivers]{odbcListDrivers()}} collects information on the available \emph{drivers}. On MacOS
+and Linux, the analogous configuration file to \code{odbc.ini} for drivers is
+\code{odbcinst.ini}.
 }

--- a/man/odbcListDrivers.Rd
+++ b/man/odbcListDrivers.Rd
@@ -10,26 +10,109 @@ odbcListDrivers(
 )
 }
 \arguments{
-\item{keep}{A character vector of driver names to keep in the results, if
-\code{NULL} (the default) will keep all drivers.}
+\item{keep}{A character vector of driver names to keep in the results.
+If \code{NULL}, all driver names will be kept.
+Set the \code{odbc.drivers_keep} option to always keep a set of driver names.}
 
-\item{filter}{A character vector of driver names to filter from the results, if
-\code{NULL} (the default) will not filter any drivers.}
+\item{filter}{A character vector of driver names to remove from the results.
+If \code{NULL}, no driver names will be removed.
+Set the \code{odbc.drivers_remove} option to always remove a set of driver names.}
 }
 \value{
 A data frame with three columns.
-If a given driver does not have any attributes the last two columns will be
-\code{NA}. Drivers can be excluded from being returned by setting the
-\code{odbc.drivers.filter} option.
+
 \describe{
-\item{name}{Name of the driver}
-\item{attribute}{Driver attribute name}
-\item{value}{Driver attribute value}
+\item{name}{Name of the driver. The entries in this column can be
+passed to the \code{driver} argument of \code{\link[=dbConnect]{dbConnect()}} (as long as the
+driver accepts the argument).}
+\item{attribute}{Driver attribute name.}
+\item{value}{Driver attribute value.}
 }
 }
 \description{
-List the available drivers on your system. See the
-\href{https://github.com/r-dbi/odbc#installation}{Installation} section of the
-package README for details on how to install drivers for the most common
-databases.
+Collect information about the available driver names.
+}
+\details{
+Driver names are first processed with \code{keep}, then \code{filter}. Thus, if a
+driver name is in both \code{keep} and \code{filter}, it won't appear in output.
+
+If a driver has multiple attributes, there will be one row per attribute,
+each with the same driver \code{name}. If a given driver name does not have any
+attributes, the function will return one row with the driver \code{name}, but
+the last two columns will be \code{NA}.
+}
+\section{Configuration}{
+
+
+This function interfaces with the driver manager to collect information
+about the available driver names.
+
+For \strong{MacOS and Linux}, the odbc package supports the unixODBC driver
+manager. unixODBC looks to the \code{odbcinst.ini} \emph{configuration file} for
+information on driver names. Install unixODBC with \verb{brew install unixodbc},
+and find the location(s) of your \code{odbcinst.ini} file(s) with \code{odbcinst -j}.
+
+In this example \code{odbcinst.ini} file:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{[MySQL Driver]
+Driver=/opt/homebrew/Cellar/mysql/8.2.0_1/lib/libmysqlclient.dylib
+}\if{html}{\out{</div>}}
+
+...the driver name is \verb{MySQL Driver}, which will appear in the \code{name}
+column of this function's output. To pass the driver name as the \code{driver}
+argument to \code{\link[=dbConnect]{dbConnect()}}, pass it as a string, like \code{"MySQL Driver"}.
+
+\strong{Windows} is \href{https://learn.microsoft.com/en-us/sql/odbc/admin/odbc-data-source-administrator}{bundled}
+with an ODBC driver manager.
+
+In this example, function output would include 1 row: the \code{name} column
+would read \code{"MySQL Driver"}, \code{attribute} would be \code{"Driver"}, and \code{value}
+would give the file path to the driver. Additional key-value pairs
+under the driver name would add additional rows with the same \code{name} entry.
+
+When a driver is configured with a driver manager, information on the driver
+will be automatically passed on to \code{\link[=dbConnect]{dbConnect()}} when its \code{driver} argument
+is set. Further, if a data source name (DSN) is configured with a driver,
+information on the driver will automatically passed on to to \code{\link[=dbConnect]{dbConnect()}}
+without needing to pass the \code{driver} argument. For an example, see the same
+section in the \code{\link[=odbcListDataSources]{odbcListDataSources()}} help-file.
+}
+
+\section{Learn more}{
+
+
+To learn more about databases:
+\itemize{
+\item \href{https://solutions.posit.co/connections/db/}{"Best Practices in Working with Databases"}
+documents how to use the odbc package with various popular databases.
+\item \href{https://github.com/mkleehammer/pyodbc/wiki/Drivers-and-Driver-Managers}{The pyodbc "Drivers and Driver Managers" Wiki}
+provides further context on drivers and driver managers.
+\item \href{https://learn.microsoft.com/en-us/sql/odbc/reference}{Microsoft's "Introduction to ODBC"}
+is a thorough resource on the ODBC interface.
+}
+}
+
+\examples{
+\dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+odbcListDrivers()
+
+# retain only attributes on the SQLite Driver
+odbcListDrivers(keep = "SQLite Driver")
+
+# remove results pertaining to the SQLite Driver
+odbcListDrivers(filter = "SQLite Driver")
+
+# to always keep or remove only results for a given driver,
+# use the odbc.drivers_keep and odbc.drivers_filter options
+options(odbc.drivers_keep = "SQLite Driver")
+odbcListDrivers()
+
+# to set that option back to its default:
+options(odbc.drivers_keep = NULL)
+\dontshow{\}) # examplesIf}
+}
+\seealso{
+\code{\link[=odbcListDataSources]{odbcListDataSources()}} collects information on the available data source
+names (DSNs). On MacOS and Linux, the analogous configuration file to
+\code{odbcinst.ini} for DSNs is \code{odbc.ini}.
 }


### PR DESCRIPTION
When getting started, I initially had trouble figuring out how to get a driver / DSN correctly configured. It seemed the existing docs assumed I had a connection configured already, though `?odbcListDataSources()` directed folks to the README if they happen to stumble across it.

As of #647, we now direct people to `?odbcListDataSources()` and `?odbcListDrivers()` from the `?dbConnect()` docs. This PR revamps the docs for those pages.

After this PR, I'd like to revisit the installation docs in the `README` and `setup.md`. I think `README` could be a strong venue to establish the mental model and link out to other places for the nitty gritty. I _do_ see the benefits of listing out all of the right `brew install` or `apt-get` incantations in one place, though that content seems 1) more developer-focused, as many docs I've seen online seem to imply that a user is likely to be working in a context where those drivers are already installed, and 2) well-served by good setup helpers (see #634).
