### PR TITLE
clarify test setup installation in `setup.md`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,7 +26,6 @@
 ^revdep$
 ^testing$
 ^CRAN-RELEASE$
-^setup.md$
 ^inst/diagrams\.key$
 ^man/figures/r-interface\.png$
 ^\.github/workflows/R-CMD-check\.yaml$

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -4,7 +4,7 @@ odbc is stable, though there are still corner cases where it could have issues w
 
 ## Known outstanding issues
 
-https://github.com/r-dbi/odbc/blob/main/setup.md contains instructions on running the tests locally, which is important to make the feedback loop shorter.
+The "Developing odbc" vignette at `vignette("develop")` contains instructions on running the tests locally, which is important to make the feedback loop shorter.
 
 The hardest part of maintaining odbc is often an issue only occurs with a specific database, and setting up the environment for that database usually takes a non-trivial amount of time.
 

--- a/setup.md
+++ b/setup.md
@@ -12,12 +12,62 @@ We need to install the RODBC package for benchmarking in the vignette `vignette(
 install.packages("RODBC", type = "source", INSTALL_opts="--configure-args='--with-odbc-manager=odbc'")
 ```
 
-## PostgreSQL and MySQL
+## PostgreSQL
 
-Run them locally with `brew services start mysql` `brew services start postgres`
-Create a 'test' database and a 'postgres' user with 'password' as the password.
+On MacOS, install PostgreSQL and the PostgreSQL drivers with:
 
-See the configuration files in .github/odbc for examples.
+```shell
+brew install postgresql@14
+brew install psqlodbc
+```
+
+Then, ensure that the `obdc.ini` and `odbcinst.ini` configuration files note an entry for PostgreSQL. For example entries in those files, see `.github/odbc`. To locate the driver on your system, see the output of `brew info psqlodbc`.
+
+To launch a PostgreSQL server locally, run:
+
+```
+brew services start postgresql@14
+```
+
+Next, create a database called "test" (or by whatever name is in the entry `Database` in your `odbc.ini` file:
+
+```shell
+createdb test
+```
+
+At this point, you should be able to connect to PostgreSQL through the R interface. Connect with:
+
+```r
+postgres <- dbConnect(odbc(), "PostgreSQL")
+```
+
+## MySQL
+
+First, installing MySQL with Homebrew:
+
+```shell
+brew install mysql@8.2
+```
+
+Ensure that the `obdc.ini` and `odbcinst.ini` configuration files note an entry for MySQL. For example entries in those files, see `.github/odbc`. To locate the driver on your system, see the output of `brew info mysql`.
+
+To launch a MySQL server locally, run:
+
+```
+brew services start mysql
+```
+
+Confirm that MySQL ran successfully with `brew services info mysql`. (If the server is not running, see [these instructions](https://stackoverflow.com/a/72984717/14038605).) Next, create a database called "test" (or by whatever name is in the entry `Database` in your `odbc.ini` file:
+
+```shell
+createdb test
+```
+
+At this point, you should be able to connect to MySQL through the R interface. Connect with:
+
+```r
+mysql <- dbConnect(odbc(), "MySQL")
+```
 
 ## SQL Server test setup
 

--- a/setup.md
+++ b/setup.md
@@ -1,8 +1,6 @@
 ## Test Setup
 
-This file contains settings needed to setup local testing of odbc. It is most
-useful for someone trying to develop the R package, so they can run the unit
-tests locally.
+While the odbc package contains some documentation on how to install and configure database drivers in `vignette("setup")`, the documentation assumes that users are connecting to databases that have already been set up. In order to test package functionality, though, odbc sets up small example database deployments. This file documents how to set up the needed dependencies to host these databases locally and is intended for developers of the R package.
 
 ## PostgreSQL and MySQL
 

--- a/setup.md
+++ b/setup.md
@@ -128,11 +128,11 @@ port = 1433
 Database = test
 ```
 
-# Oracle
+## Oracle
 
 A huge pain.
 
-## Get the DB container
+Get the DB container:
 
 ```shell
 docker login
@@ -140,21 +140,22 @@ docker login
 docker pull store/oracle/database-enterprise:12.2.0.1
 ```
 
-## Start the container
-
-The -P is important to setup the port forwarding from the docker container
+Start the container:
 
 ```shell
 docker run -d -it --name oracle_db -P store/oracle/database-enterprise:12.2.0.1
 ```
 
-## Query the port and edit the ports in tnsnames.ora
+The `-P` is important to set up the port forwarding from the docker container.
+
+
+Then, query the port and edit the ports in `tnsnames.ora`:
 
 ```shell
 docker port oracle_db
 ```
 
-Contents of `snsnames.ora`
+The contents of `snsnames.ora` should look like:
 
 ```
 ORCLCDB=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=32769))
@@ -163,11 +164,13 @@ ORCLPDB1=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=32769))
     (CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=ORCLPDB1.localdomain)))
 ```
 
-Set the current working directory as the 
+Ensure that the current working directly is [set appropriately](https://www.ibm.com/support/pages/how-configure-tnsnamesora-use-dedicated-server-process-datastage-connections-oracle-databases#:~:text=accessed%20via%20DataStage%3A-,The%20tnsnames.,specified%20by%20the%20TNS_ADMIN%20variable.). 
 
-## Add a new user to the DB
+Then, to add a new user to the database:
 
+```shell
 docker exec -it oracle_db bash -c "source /home/oracle/.bashrc; sqlplus SYS/Oradoc_db1 AS SYSDBA"
+```
 
 ```sql
 alter session set "_ORACLE_SCRIPT"=true;
@@ -176,6 +179,8 @@ create user test identified by 12345;
 
 GRANT ALL PRIVILEGES TO TEST;
 ```
+
+Finally, in R:
 
 ```r
 Sys.setenv("TNS_ADMIN" = getwd())

--- a/vignettes/benchmarks.Rmd
+++ b/vignettes/benchmarks.Rmd
@@ -26,6 +26,12 @@ The odbc package is often much faster than the existing
 [RODBC](https://cran.r-project.org/package=RODBC) and DBI compatible
 [RODBCDBI](https://cran.r-project.org/package=RODBCDBI) packages. We'll benchmark writing and reading data from the [nycflights13](https://github.com/tidyverse/nycflights13) package using the three packages.
 
+```{r, include = FALSE}
+# The CRAN version of RODBC uses iODBC, so to use unixODBC we need to 
+# recompile it from source, specifying the odbc manager explicitly:
+# install.packages("RODBC", type = "source", INSTALL_opts="--configure-args='--with-odbc-manager=odbc'")
+```
+
 ```{r setup}
 library(odbc)
 library(RODBC)

--- a/vignettes/benchmarks.Rmd
+++ b/vignettes/benchmarks.Rmd
@@ -29,7 +29,10 @@ The odbc package is often much faster than the existing
 ```{r, include = FALSE}
 # The CRAN version of RODBC uses iODBC, so to use unixODBC we need to 
 # recompile it from source, specifying the odbc manager explicitly:
+#
 # install.packages("RODBC", type = "source", INSTALL_opts="--configure-args='--with-odbc-manager=odbc'")
+#
+# see `vignette("develop")` for more details.
 ```
 
 ```{r setup}

--- a/vignettes/develop.Rmd
+++ b/vignettes/develop.Rmd
@@ -245,6 +245,17 @@ port = 1433
 Database = test
 ```
 
+## SQLite
+
+MacOS provides SQLite natively. With the SQLite odbc driver installed (see `vignette("setup")` if needed), run:
+
+```
+library(odbc)
+dbConnect(odbc(), "SQLite")
+```
+
+The above example assumes the configured SQLite DSN is called `"SQLite"`.
+
 ## Oracle
 
 A huge pain.
@@ -303,6 +314,7 @@ Finally, in R:
 Sys.setenv("TNS_ADMIN" = getwd())
 con <- dbConnect(odbc::odbc(), "OracleODBC-19")
 ```
+
 
 ## RODBC
 

--- a/vignettes/develop.Rmd
+++ b/vignettes/develop.Rmd
@@ -59,7 +59,7 @@ First, installing MySQL with Homebrew:
 brew install mysql@8.2
 ```
 
-Available installers of the MySQL drivers (called the Connector/ODBC for MySQL) on Unix systems assume the iODBC driver manager. The driver thus needs to be installed from source.
+Available installers of the MySQL drivers (called the Connector/ODBC for MySQL) on macOS assume the iODBC driver manager. The driver thus needs to be installed from source.
 
 Clone the [mysql-connector-odbc source](https://github.com/mysql/mysql-connector-odbc).
 

--- a/vignettes/develop.Rmd
+++ b/vignettes/develop.Rmd
@@ -59,80 +59,27 @@ First, installing MySQL with Homebrew:
 brew install mysql@8.2
 ```
 
-Available installers of the MySQL drivers (called the Connector/ODBC for MySQL) on macOS assume the iODBC driver manager. The driver thus needs to be installed from source.
-
-Clone the [mysql-connector-odbc source](https://github.com/mysql/mysql-connector-odbc).
-
-Edit the source of `dltest/dltest.c` to include:
-
-```c
-#include <string.h>
-```
-
-in the first few lines, and similarly for `test/odbctap.h`:
-
-```c
-#include <wchar.h>
-#include <stdio.h>
-```
-
-Set the working directory to the source project (this will already be done if you've opened the repository as an RStudio project). Then, run:
+MariaDB drivers are compatible with MySQL and are more easily installed than MySQL drivers themselves in most cases. To install the MariaDB driver:
 
 ```shell
-brew install openssl@3
+brew install mariadb-connector-odbc
 ```
 
-We'll tell the MySQL connection to compile with unixODBC and a homebrew install of openssl. Use `brew info openssl@3` to locate your install of openssl. Substitute `2.3.12` below with the version of your unixODBC install appropriately by navigating to `/opt/homebrew/Cellar/unixodbc/` and choosing the most recent installation.
+Then, link the MariaDB driver with your MySQL data source name. That is, with the driver name `[MariaDB]` configuring your MariaDB install in `odbcinst.ini`, the first lines of your `odbc.ini` entry should look something like:
 
-Then:
-
-```shell
-cmake -G "Unix Makefiles" -DWITH_UNIXODBC=1 -DWITH_SSL=/opt/homebrew/opt/openssl@3 -DODBC_INCLUDES=/opt/homebrew/Cellar/unixodbc/2.3.12/include -DODBC_LIB_DIR=/opt/homebrew/Cellar/unixodbc/2.3.12/lib
-```
-
-Towards the end of log outputs, you should see:
-
-```
--- OpenSSL library: /opt/homebrew/opt/openssl@3/lib/libssl.dylib
-```
-
-or similar. If you see "not found," you will need to [troubleshoot your SSL library path](https://dev.mysql.com/doc/refman/8.0/en/source-ssl-library-configuration.html). 
-
-Finally:
-
-```
-make
-
-sudo make install
-```
-
-For more information on the above, see [MySQL's docs](https://dev.mysql.com/doc/connector-odbc/en/connector-odbc-installation-source-unix.html) and the arguments noted on the [installation documentation](https://dev.mysql.com/doc/connector-odbc/en/connector-odbc-installation-source-unix.html); you will likely need to set additional arguments.
-
-At the `make` step, you may see an error related to missing libraries.  If so, you'll need to (re)install the noted library with brew, clear the results of `cmake` from the source directory (I used `usethis:::git_clean()` to do so), and start again from the `cmake` step.
-
-```
-is a symlink belonging to openssl@3. You can unlink it:
-  brew unlink openssl@3
-
-To force the link and overwrite all conflicting files:
-  brew link --overwrite openssl@1.1
-```
-
-Once the driver is correctly installed, find the sample `.ini` files linked in the `sudo make install` output and add them to your configuration files noted in `odbcinst -j`. Remove the `DATABASE` key entry and set:
-
-```
-UID             = root
-PASSWORD        =
+```ini
+[MySQL]
+Driver = MariaDB
 ```
 
 After running `brew services start mysql` if needed, and confirming that the database is running with `brew services info mysql`, you should be able to:
 
 ```
 library(odbc)
-dbConnect(odbc(), "myodbc8w")
+dbConnect(odbc(), "MySQL")
 ```
 
-Where `"myodbc8w"` is substituted with the DSN you've configured.
+The second argument `"MySQL"` refers to the data source name configured above.
 
 ## SQL Server test setup
 

--- a/vignettes/develop.Rmd
+++ b/vignettes/develop.Rmd
@@ -22,14 +22,14 @@ For the most part, this vignette assumes a MacOS system with aarch64 (e.g. M1 or
 
 ## PostgreSQL
 
-On MacOS, install PostgreSQL and the PostgreSQL drivers with:
+On MacOS, install PostgreSQL with:
 
 ```shell
 brew install postgresql@14
-brew install psqlodbc
+
 ```
 
-Then, ensure that the `obdc.ini` and `odbcinst.ini` configuration files note an entry for PostgreSQL. For example entries in those files, see `.github/odbc`. To locate the driver on your system, see the output of `psqlodbc | grep -E '.(dylib|so)$'`.
+You'll also need to install and configure the PostgreSQL driver `psqlodbc`; see `vignette("setup")` to learn more.
 
 To launch a PostgreSQL server locally, run:
 

--- a/vignettes/develop.Rmd
+++ b/vignettes/develop.Rmd
@@ -1,6 +1,20 @@
-## Test Setup
+---
+title: "Developing odbc"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Developing odbc}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
 
-This file is intended to help developers of the R package install needed dependencies.
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+This vignette is intended to help developers of the R package install needed dependencies.
 
 While the odbc package contains some documentation on how to install and configure database drivers in `vignette("setup")`, the documentation assumes that users are connecting to databases that have already been set up. In order to test package functionality, though, odbc sets up small example database deployments.
 

--- a/vignettes/develop.Rmd
+++ b/vignettes/develop.Rmd
@@ -26,7 +26,6 @@ On MacOS, install PostgreSQL with:
 
 ```shell
 brew install postgresql@14
-
 ```
 
 You'll also need to install and configure the PostgreSQL driver `psqlodbc`; see `vignette("setup")` to learn more.
@@ -167,14 +166,7 @@ port = 1433
 Encrypt = no
 ```
 
-In  `odbcinst.ini`:
-
-```ini
-[ODBC Driver 18 for SQL Server]
-Description=Microsoft ODBC Driver 18 for SQL Server
-Driver=/opt/homebrew/lib/libmsodbcsql.18.dylib
-UsageCount=1
-```
+With the driver name in `odbcinst.ini` being `[ODBC Driver 18 for SQL Server]`.
 
 With docker and the needed driver installed, deploy the container with:
 
@@ -194,11 +186,12 @@ The `--platform` tag is correct for M1; if you see `Status: Exited (1)` in Docke
 To connect via odbc, we need to pass the UID and PWD via the connection string; configuring those arguments via `odbc.ini` is [not permitted](https://stackoverflow.com/questions/42387084/sql-server-odbc-driver-linux-username). With the container deployed as above, the connection arguments would be:
 
 ```r
-con <- dbConnect(odbc::odbc(), 
-                 dsn = "MicrosoftSQLServer", 
-                 uid = "SA", 
-                 pwd = "BoopBop123!"
-                 )
+con <- dbConnect(
+  odbc::odbc(), 
+  dsn = "MicrosoftSQLServer", 
+  uid = "SA", 
+  pwd = "BoopBop123!"
+)
 ```
 
 Then do some configuration of the server to add a testuser and create the test database

--- a/vignettes/develop.Rmd
+++ b/vignettes/develop.Rmd
@@ -18,6 +18,8 @@ This vignette is intended to help developers of the R package install needed dep
 
 While the odbc package contains some documentation on how to install and configure database drivers in `vignette("setup")`, the documentation assumes that users are connecting to databases that have already been set up. In order to test package functionality, though, odbc sets up small example database deployments.
 
+For the most part, this vignette assumes a MacOS system with aarch64 (e.g. M1 or M2) architecture. For Linux example code, see [`.github/workflows/db.yaml`](https://github.com/r-dbi/odbc/blob/main/.github/workflows/db.yaml), and for Windows, see [`.github/workflows/db-windows.yml`](https://github.com/r-dbi/odbc/blob/main/.github/workflows/db-windows.yml).
+
 ## PostgreSQL
 
 On MacOS, install PostgreSQL and the PostgreSQL drivers with:

--- a/vignettes/setup.Rmd
+++ b/vignettes/setup.Rmd
@@ -53,6 +53,7 @@ brew install psqlodbc
 
 ## MySQL ODBC drivers (and database)
 brew install mysql
+brew install mariadb-connector-odbc
 
 ## SQLite ODBC drivers
 brew install sqliteodbc


### PR DESCRIPTION
* Clarifies the difference between this document and `vignette("setup")`
* Clarifies/updates documentation for Microsoft SQL Server, PostgreSQL, and MySQL

Closes #663. Closes #638. Closes #637. Related to #565, but does not close.

The installation for MySQL isn't quite there; I'd like to be able to close #450 as well, so have marked this as draft for now. From my understanding, we'll need to [compile Connector/ODBC for MySQL from source](https://dev.mysql.com/doc/connector-odbc/en/connector-odbc-installation-source-unix-macos.html) with [-DWITH_UNIXODBC=1](https://dev.mysql.com/doc/refman/8.0/en/source-configuration-options.html#option_cmake_with_unixodbc) (or that's my next debugging strategy, at least🙂).