### PR TITLE
Add missing ... to odbcConnectionColumns()

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -189,7 +189,7 @@ setGeneric(
 setMethod(
   "odbcConnectionColumns",
   c("OdbcConnection", "Id"),
-  function(conn, name, column_name = NULL, exact = FALSE) {
+  function(conn, name, ..., column_name = NULL, exact = FALSE) {
     odbcConnectionColumns(conn,
       name = id_field(name, "table"),
       catalog_name = id_field(name, "catalog"),
@@ -207,6 +207,7 @@ setMethod(
   c("OdbcConnection", "character"),
   function(conn,
            name,
+           ...,
            catalog_name = NULL,
            schema_name = NULL,
            column_name = NULL,

--- a/man/odbcConnectionColumns.Rd
+++ b/man/odbcConnectionColumns.Rd
@@ -10,11 +10,12 @@
 \usage{
 odbcConnectionColumns(conn, name, ..., exact = FALSE)
 
-\S4method{odbcConnectionColumns}{OdbcConnection,Id}(conn, name, column_name = NULL, exact = FALSE)
+\S4method{odbcConnectionColumns}{OdbcConnection,Id}(conn, name, ..., column_name = NULL, exact = FALSE)
 
 \S4method{odbcConnectionColumns}{OdbcConnection,character}(
   conn,
   name,
+  ...,
   catalog_name = NULL,
   schema_name = NULL,
   column_name = NULL,


### PR DESCRIPTION
Fixes `Error: Expecting a single string value: [type=logical; extent=1]` when using the RStudio connections pane. https://github.com/rstudio/rstudio-pro/issues/5581