### PR TITLE
Use SQLUINTEGER in get_info()

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -75,10 +75,10 @@ std::string get_info_or_empty(connection_ptr const& p, short type) {
 
 // [[Rcpp::export]]
 Rcpp::List connection_info(connection_ptr const& p) {
-  SQLINTEGER getdata_ext;
+  SQLUINTEGER getdata_ext;
   try {
     getdata_ext =
-        (*p)->connection()->get_info<SQLINTEGER>(SQL_GETDATA_EXTENSIONS);
+        (*p)->connection()->get_info<SQLUINTEGER>(SQL_GETDATA_EXTENSIONS);
   } catch (const nanodbc::database_error& c) {
     getdata_ext = 0;
   }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -75,10 +75,10 @@ std::string get_info_or_empty(connection_ptr const& p, short type) {
 
 // [[Rcpp::export]]
 Rcpp::List connection_info(connection_ptr const& p) {
-  unsigned short getdata_ext;
+  SQLINTEGER getdata_ext;
   try {
     getdata_ext =
-        (*p)->connection()->get_info<unsigned short>(SQL_GETDATA_EXTENSIONS);
+        (*p)->connection()->get_info<SQLINTEGER>(SQL_GETDATA_EXTENSIONS);
   } catch (const nanodbc::database_error& c) {
     getdata_ext = 0;
   }

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -1266,6 +1266,7 @@ string_type connection::connection_impl::database_name() const
 
 template string_type connection::get_info(short info_type) const;
 template unsigned short connection::get_info(short info_type) const;
+template SQLUINTEGER connection::get_info(short info_type) const;
 template uint32_t connection::get_info(short info_type) const;
 template uint64_t connection::get_info(short info_type) const;
 

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -1265,10 +1265,8 @@ string_type connection::connection_impl::database_name() const
 }
 
 template string_type connection::get_info(short info_type) const;
-template unsigned short connection::get_info(short info_type) const;
+template SQLUSMALLINT connection::get_info(short info_type) const;
 template SQLUINTEGER connection::get_info(short info_type) const;
-template uint32_t connection::get_info(short info_type) const;
-template uint64_t connection::get_info(short info_type) const;
 
 } // namespace nanodbc
 

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -1266,7 +1266,6 @@ string_type connection::connection_impl::database_name() const
 
 template string_type connection::get_info(short info_type) const;
 template unsigned short connection::get_info(short info_type) const;
-template SQLINTEGER connection::get_info(short info_type) const;
 template uint32_t connection::get_info(short info_type) const;
 template uint64_t connection::get_info(short info_type) const;
 

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -1266,6 +1266,7 @@ string_type connection::connection_impl::database_name() const
 
 template string_type connection::get_info(short info_type) const;
 template unsigned short connection::get_info(short info_type) const;
+template SQLINTEGER connection::get_info(short info_type) const;
 template uint32_t connection::get_info(short info_type) const;
 template uint64_t connection::get_info(short info_type) const;
 


### PR DESCRIPTION
Instead of `unsigned short`, which could be allocated or aligned differently by different compilers.

There are other places in nanodbc that use `unsigned short` in the protocol, so potentially those are broken as well.

I am not very familiar with the ODBC toolchain, so it is possible that this is not the best fix, but nevertheless this is the step that causes the memory error and the crash, so this needs to change.

For #624.