### PR TITLE
Silence deprecation warning

### DIFF
--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -298,7 +298,10 @@ inline void convert(const wide_string_type& in, std::string& out)
         nullptr,
         nullptr);
 #else
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     out = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().to_bytes(in);
+# pragma GCC diagnostic pop
 #endif
 #endif
 #endif


### PR DESCRIPTION
Since this needs to be fixed upstream and there's no obvious replacement available (https://github.com/nanodbc/nanodbc/issues/74).