### PR TITLE
tets: cleanup sql server warning

### DIFF
--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -263,6 +263,7 @@ test_that("SQLServer", {
     rs <- dbSendStatement(con, paste0("SELECT * FROM ", tblName))
     expect_equal(nrow(dbFetch(rs, n = 0)), 0)
     expect_equal(nrow(dbFetch(rs, n = 10)), 2)
+    dbClearResult(rs)
   })
 
   test_that("isTempTable tests", {


### PR DESCRIPTION
Clean up a warning in the SQL server test suite.

Previously:

```
Warning (/home/docker/odbc/R/dbi-table.R:292:5): Zero-row-fetch does not move cursor
Cancelling previous query
Backtrace:

 1. ├─DBI::dbRemoveTable(con, tblName)
 2. └─odbc::dbRemoveTable(con, tblName)
 3.   ├─DBI::dbExecute(conn, paste("DROP TABLE ", name)) at
odbc/R/dbi-table.R:292:4
 4.   └─DBI::dbExecute(conn, paste("DROP TABLE ", name))
 5.     ├─DBI::dbSendStatement(conn, statement, ...)
 6.     └─odbc::dbSendStatement(conn, statement, ...)
 7.       └─odbc (local) .local(conn, statement, ...)
 8.         └─odbc:::OdbcResult(...) at odbc/R/dbi-connection.R:100:4
 9.           └─odbc:::new_result(p = connection@ptr, sql = statement, immediate = immediate) at odbc/R/dbi-result.R:16:2
```