### PR TITLE
SQL Server dbExists temporary table fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 # odbc (development version)
 
-## Driver specific changes
-
-* SQL Server Fix `dbExists` for temporary table (#724).
+* SQL Server Fix `dbExists` for temporary table (@meztez, #724).
 
 # odbc 1.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # odbc (development version)
 
+## Driver specific changes
+
+* SQL Server Fix `dbExists` for temporary table (#720).
+
 # odbc 1.4.1
 
 * New `odbcListConfig()` lists configuration files on Mac and Linux 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Driver specific changes
 
-* SQL Server Fix `dbExists` for temporary table (#723).
+* SQL Server Fix `dbExists` for temporary table (#724).
 
 # odbc 1.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Driver specific changes
 
-* SQL Server Fix `dbExists` for temporary table (#720).
+* SQL Server Fix `dbExists` for temporary table (#723).
 
 # odbc 1.4.1
 

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -72,17 +72,12 @@ setMethod("dbExistsTable", c("Microsoft SQL Server", "character"),
   function(conn, name, ...) {
     stopifnot(length(name) == 1)
     if (isTempTable(conn, name, ...)) {
-      name <- paste0(name, "\\_\\_\\_%")
-      df <- odbcConnectionTables(
-        conn,
-        name,
-        catalog_name = "tempdb",
-        schema_name = "dbo"
-      )
+      query <- paste0("SELECT OBJECT_ID('tempdb..", name, "')")
+      !is.na(dbGetQuery(con, query)[[1]])
     } else {
       df <- odbcConnectionTables(conn, name = name, ...)
+      NROW(df) > 0
     }
-    NROW(df) > 0
   }
 )
 

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -73,7 +73,7 @@ setMethod("dbExistsTable", c("Microsoft SQL Server", "character"),
     stopifnot(length(name) == 1)
     if (isTempTable(conn, name, ...)) {
       query <- paste0("SELECT OBJECT_ID('tempdb..", name, "')")
-      !is.na(dbGetQuery(con, query)[[1]])
+      !is.na(dbGetQuery(conn, query)[[1]])
     } else {
       df <- odbcConnectionTables(conn, name = name, ...)
       NROW(df) > 0

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -277,6 +277,7 @@ test_that("SQLServer", {
 
   test_that("dbExistsTable accounts for local temp tables", {
     con <- DBItest:::connect(DBItest:::get_default_context())
+    con2 <- DBItest:::connect(DBItest:::get_default_context())
     tbl_name <- "#myTemp"
     tbl_name2 <- "##myTemp"
     tbl_name3 <- "#myTemp2"
@@ -291,6 +292,8 @@ test_that("SQLServer", {
     expect_true(!dbExistsTable(con, tbl_name2, catalog_name = "tempdb"))
     # Fail because table not actually present
     expect_true(!dbExistsTable(con, tbl_name3, catalog_name = "tempdb"))
+    # Fail because table was created in another live session
+    expect_true(!dbExistsTable(con2, tbl_name))
   })
 
   test_that("Create / write to temp table", {


### PR DESCRIPTION
On SQL Server, dbExists does not take into account coexisting sessions.

See #719 