### PR TITLE
Refactor database tests into individual test blocks

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -138,3 +138,9 @@ is_windows <- function() {
 }
 
 compact <- function(x) x[!vapply(x, is.null, logical(1))]
+
+random_name <- function(prefix = "") {
+  vals <- c(letters, LETTERS, 0:9)
+  name <- paste0(sample(vals, 10, replace = TRUE), collapse = "")
+  paste0(prefix, "odbc_", name)
+}

--- a/tests/testthat/_snaps/driver-sql-server.md
+++ b/tests/testthat/_snaps/driver-sql-server.md
@@ -1,3 +1,22 @@
+# dbWriteTable errors if field.types don't exist (#271)
+
+    Code
+      sqlCreateTable(con, "foo", iris, field.types = list(bar = "[int]"))
+    Condition
+      Warning:
+      Some columns in `field.types` not in the input, missing columns:
+        - 'bar'
+    Output
+      <SQL> CREATE TABLE "foo" (
+        "Sepal.Length" FLOAT,
+        "Sepal.Width" FLOAT,
+        "Petal.Length" FLOAT,
+        "Petal.Width" FLOAT,
+        "Species" varchar(255),
+        "bar" [int]
+      )
+      
+
 # can create / write to temp table
 
     Temporary flag is set to true, but table name doesn't use # prefix

--- a/tests/testthat/_snaps/driver-sql-server.md
+++ b/tests/testthat/_snaps/driver-sql-server.md
@@ -1,4 +1,4 @@
-# Create / write to temp table
+# can create / write to temp table
 
     Temporary flag is set to true, but table name doesn't use # prefix
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -9,10 +9,11 @@ test_connection_string <- function(db) {
   list(.connection_string = cs)
 }
 
-test_con <- function(db) {
+test_con <- function(db, ...) {
   dbConnect(
     odbc::odbc(),
-    .connection_string = test_connection_string(db)
+    .connection_string = test_connection_string(db),
+    ...
   )
 }
 
@@ -51,7 +52,7 @@ skip_if_no_drivers <- function() {
 #' # Only test a specific column
 #' test_roundtrip(con, "integer", invert = FALSE)
 #' }
-test_roundtrip <- function(con = DBItest:::connect(DBItest::get_default_context()), columns = "", invert = TRUE, force_sorted = FALSE) {
+test_roundtrip <- function(con, columns = "", invert = TRUE, force_sorted = FALSE) {
   dbms <- dbGetInfo(con)$dbms.name
   res <- list()
   testthat::test_that(paste0("[", dbms, "] round tripping data.frames works"), {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -17,6 +17,13 @@ test_con <- function(db, ...) {
   )
 }
 
+local_table <- function(con, name, df, ..., envir = parent.frame()) {
+  dbWriteTable(con, name, df, ...)
+  withr::defer(dbRemoveTable(con, name), envir = envir)
+
+  name
+}
+
 skip_if_no_drivers <- function() {
   if (nrow(odbcListDrivers()) == 0) {
     skip("No drivers installed")

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -12,7 +12,7 @@ test_connection_string <- function(db) {
 test_con <- function(db) {
   dbConnect(
     odbc::odbc(),
-    .connection_string = test_connection_string("SQLSERVER")
+    .connection_string = test_connection_string(db)
   )
 }
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -9,6 +9,13 @@ test_connection_string <- function(db) {
   list(.connection_string = cs)
 }
 
+test_con <- function(db) {
+  dbConnect(
+    odbc::odbc(),
+    .connection_string = test_connection_string("SQLSERVER")
+  )
+}
+
 skip_if_no_drivers <- function() {
   if (nrow(odbcListDrivers()) == 0) {
     skip("No drivers installed")

--- a/tests/testthat/test-driver-mysql.R
+++ b/tests/testthat/test-driver-mysql.R
@@ -93,7 +93,7 @@ test_that("odbcPreviewObject", {
 
   # There should be no "Pending rows" warning
   expect_no_warning({
-    res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)
+    res <- odbcPreviewObject(con, rowLimit = 3, table = tbl)
   })
   expect_equal(nrow(res), 3)
 })

--- a/tests/testthat/test-driver-mysql.R
+++ b/tests/testthat/test-driver-mysql.R
@@ -83,31 +83,35 @@ test_that("MySQL", {
   ))
 
   test_roundtrip(columns = c("logical", "binary"))
-  test_that("odbcPreviewObject", {
-    tblName <- "test_preview"
-    con <- DBItest:::connect(DBItest:::get_default_context())
-    dbWriteTable(con, tblName, data.frame(a = 1:10L))
-    on.exit(dbRemoveTable(con, tblName))
-    # There should be no "Pending rows" warning
-    expect_no_warning({
-      res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)
-    })
-    expect_equal(nrow(res), 3)
+})
+
+test_that("odbcPreviewObject", {
+  con <- test_con("MYSQL")
+
+  tblName <- "test_preview"
+  dbWriteTable(con, tblName, data.frame(a = 1:10L))
+  on.exit(dbRemoveTable(con, tblName))
+  # There should be no "Pending rows" warning
+  expect_no_warning({
+    res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)
   })
-  test_that("sproc result retrieval", {
-    sprocName <- "testSproc"
-    con <- DBItest:::connect(DBItest:::get_default_context())
-    DBI::dbExecute(
-      con,
-      paste0("CREATE PROCEDURE ", sprocName, "(IN arg INT) BEGIN SELECT 'abc' as TestCol; END")
-    )
-    on.exit(DBI::dbExecute(con, paste0("DROP PROCEDURE ", sprocName)))
-    expect_no_error({
-      res <- dbGetQuery(con, paste0("CALL ", sprocName, "(1)"))
-    })
-    expect_identical(
-      res,
-      data.frame("TestCol" = "abc", stringsAsFactors = FALSE)
-    )
+  expect_equal(nrow(res), 3)
+})
+
+test_that("sproc result retrieval", {
+  con <- test_con("MYSQL")
+
+  sprocName <- "testSproc"
+  DBI::dbExecute(
+    con,
+    paste0("CREATE PROCEDURE ", sprocName, "(IN arg INT) BEGIN SELECT 'abc' as TestCol; END")
+  )
+  on.exit(DBI::dbExecute(con, paste0("DROP PROCEDURE ", sprocName)))
+  expect_no_error({
+    res <- dbGetQuery(con, paste0("CALL ", sprocName, "(1)"))
   })
+  expect_identical(
+    res,
+    data.frame("TestCol" = "abc", stringsAsFactors = FALSE)
+  )
 })

--- a/tests/testthat/test-driver-mysql.R
+++ b/tests/testthat/test-driver-mysql.R
@@ -87,10 +87,8 @@ test_that("MySQL", {
 
 test_that("odbcPreviewObject", {
   con <- test_con("MYSQL")
+  tbl <- local_table(con, "test_preview", data.frame(a = 1:10L))
 
-  tblName <- "test_preview"
-  dbWriteTable(con, tblName, data.frame(a = 1:10L))
-  on.exit(dbRemoveTable(con, tblName))
   # There should be no "Pending rows" warning
   expect_no_warning({
     res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)
@@ -107,6 +105,7 @@ test_that("sproc result retrieval", {
     paste0("CREATE PROCEDURE ", sprocName, "(IN arg INT) BEGIN SELECT 'abc' as TestCol; END")
   )
   on.exit(DBI::dbExecute(con, paste0("DROP PROCEDURE ", sprocName)))
+
   expect_no_error({
     res <- dbGetQuery(con, paste0("CALL ", sprocName, "(1)"))
   })

--- a/tests/testthat/test-driver-mysql.R
+++ b/tests/testthat/test-driver-mysql.R
@@ -81,8 +81,10 @@ test_that("MySQL", {
     "reexport",
     NULL
   ))
+})
 
-  test_roundtrip(columns = c("logical", "binary"))
+test_that("can roundtrip columns", {
+  test_roundtrip(test_con("MYSQL"), columns = c("logical", "binary"))
 })
 
 test_that("odbcPreviewObject", {

--- a/tests/testthat/test-driver-oracle.R
+++ b/tests/testthat/test-driver-oracle.R
@@ -15,6 +15,6 @@ test_that("can detect existance of table", {
   tbl1 <- local_table(con, "mtcarstest", mtcars)
   expect_true(dbExistsTable(con, tbl1))
 
-  tbl2 <- dbWriteTable(con, "mtcars_test", mtcars)
+  tbl2 <- local_table(con, "mtcars_test", mtcars)
   expect_true(dbExistsTable(con, tbl2))
 })

--- a/tests/testthat/test-driver-oracle.R
+++ b/tests/testthat/test-driver-oracle.R
@@ -12,12 +12,9 @@ test_that("can round columns", {
 test_that("can detect existance of table", {
   con <- test_con("ORACLE")
 
-  dbWriteTable(con, "mtcarstest", mtcars)
-  expect_true(dbExistsTable(con, "mtcarstest"))
-  dbWriteTable(con, "mtcars_test", mtcars)
-  expect_true(dbExistsTable(con, "mtcars_test"))
-  on.exit({
-    dbExecute(con, "DROP TABLE mtcarstest")
-    dbExecute(con, "DROP TABLE mtcars_test")
-  })
+  tbl1 <- local_table(con, "mtcarstest", mtcars)
+  expect_true(dbExistsTable(con, tbl1))
+
+  tbl2 <- dbWriteTable(con, "mtcars_test", mtcars)
+  expect_true(dbExistsTable(con, tbl2))
 })

--- a/tests/testthat/test-driver-oracle.R
+++ b/tests/testthat/test-driver-oracle.R
@@ -9,7 +9,7 @@ test_that("can round columns", {
   test_roundtrip(con, columns = c("time", "date", "datetime", "binary", "logical"))
 })
 
-test_that("can detect existance of table", {
+test_that("can detect existence of table", {
   con <- test_con("ORACLE")
 
   tbl1 <- local_table(con, "mtcarstest", mtcars)

--- a/tests/testthat/test-driver-oracle.R
+++ b/tests/testthat/test-driver-oracle.R
@@ -1,6 +1,5 @@
-test_that("Oracle", {
-
-  con <- dbConnect(odbc::odbc(), .connection_string = test_connection_string("ORACLE"))
+test_that("can round columns", {
+  con <- test_con("ORACLE")
   # - Long/outstanding issue with batch inserting
   # date/datetime for Oracle.  See for example
   # #349, #350, #391
@@ -8,17 +7,17 @@ test_that("Oracle", {
   # to binary elements of size zero.
   # - Finally, no boolean in Oracle prior to 23
   test_roundtrip(con, columns = c("time", "date", "datetime", "binary", "logical"))
+})
 
-  local({
-    # Test custom dbExistsTable implementation for
-    # Oracle
-    dbWriteTable(con, "mtcarstest", mtcars)
-    expect_true(dbExistsTable(con, "mtcarstest"))
-    dbWriteTable(con, "mtcars_test", mtcars)
-    expect_true(dbExistsTable(con, "mtcars_test"))
-    on.exit({
-      dbExecute(con, "DROP TABLE mtcarstest")
-      dbExecute(con, "DROP TABLE mtcars_test")
-    })
+test_that("can detect existance of table", {
+  con <- test_con("ORACLE")
+
+  dbWriteTable(con, "mtcarstest", mtcars)
+  expect_true(dbExistsTable(con, "mtcarstest"))
+  dbWriteTable(con, "mtcars_test", mtcars)
+  expect_true(dbExistsTable(con, "mtcars_test"))
+  on.exit({
+    dbExecute(con, "DROP TABLE mtcarstest")
+    dbExecute(con, "DROP TABLE mtcars_test")
   })
 })

--- a/tests/testthat/test-driver-postgres.R
+++ b/tests/testthat/test-driver-postgres.R
@@ -6,77 +6,6 @@ test_that("PostgreSQL", {
     name = "PostgreSQL"
   )
 
-  test_that("show method works as expected with real connection", {
-    skip_on_os("windows")
-    con <- DBItest:::connect(DBItest:::get_default_context())
-
-    expect_output(show(con), "@localhost")
-    expect_output(show(con), "Database: [a-z]+")
-    expect_output(show(con), "PostgreSQL Version: ")
-  })
-
-  test_that("64 bit integers work with alternate mappings", {
-    con_default <- DBItest:::connect(DBItest:::get_default_context())
-    con_integer64 <-
-      DBItest:::connect(DBItest:::get_default_context(), bigint = "integer64")
-    con_integer <-
-      DBItest:::connect(DBItest:::get_default_context(), bigint = "integer")
-    con_numeric <-
-      DBItest:::connect(DBItest:::get_default_context(), bigint = "numeric")
-    con_character <-
-      DBItest:::connect(DBItest:::get_default_context(), bigint = "character")
-
-    dbWriteTable(con_default, "test", data.frame(a = 1:10L), field.types = c(a = "BIGINT"))
-    on.exit(dbRemoveTable(con_default, "test"))
-
-    expect_s3_class(dbReadTable(con_default, "test")$a, "integer64")
-    expect_s3_class(dbReadTable(con_integer64, "test")$a, "integer64")
-
-    expect_type(dbReadTable(con_integer, "test")$a, "integer")
-
-    expect_type(dbReadTable(con_numeric, "test")$a, "double")
-
-    expect_type(dbReadTable(con_character, "test")$a, "character")
-  })
-
-  # This test checks whether when writing to a table and using
-  # result_describe_parameters to offer descriptions of the data
-  # we are attempting to write, our logic remains robust to the
-  # case when the data being written has columns ordered
-  # differently than the table we are targetting.
-  test_that("Writing data.frame with column ordering different than target table", {
-    tblName <- "test_order_write"
-    con <- DBItest:::connect(DBItest:::get_default_context())
-    values <- data.frame(
-      datetime = as.POSIXct(c(14, 15), origin = "2016-01-01", tz = "UTC"),
-      name = c("one", "two"),
-      num = 1:2,
-      stringsAsFactors = FALSE
-    )
-    sql <- sqlCreateTable(con, tblName, values)
-    dbExecute(con, sql)
-    on.exit(dbRemoveTable(con, tblName))
-    dbWriteTable(con, tblName, values[c(2, 3, 1)],
-      overwrite = FALSE, append = TRUE
-    )
-    received <- DBI::dbReadTable(con, tblName)
-    received <- received[order(received$num), ]
-    row.names(received) <- NULL
-    expect_equal(values, received)
-  })
-
-  test_that("odbcPreviewObject", {
-    tblName <- "test_preview"
-    con <- DBItest:::connect(DBItest:::get_default_context())
-    dbWriteTable(con, tblName, data.frame(a = 1:10L))
-    on.exit(dbRemoveTable(con, tblName))
-    # There should be no "Pending rows" warning
-    expect_no_warning({
-      res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)
-    })
-    expect_equal(nrow(res), 3)
-  })
-
   DBItest::test_getting_started(c(
     "package_name", # Not an error
     NULL
@@ -163,6 +92,77 @@ test_that("PostgreSQL", {
     "reexport", # TODO
     NULL
   ))
-
-  test_roundtrip()
 })
+
+test_that("can roundtrip columns", {
+  con <- test_con("POSTGRES")
+  test_roundtrip(con)
+})
+
+test_that("show method works as expected with real connection", {
+  skip_on_os("windows")
+  con <- test_con("POSTGRES")
+
+  expect_output(show(con), "@localhost")
+  expect_output(show(con), "Database: [a-z]+")
+  expect_output(show(con), "PostgreSQL Version: ")
+})
+
+test_that("64 bit integers work with alternate mappings", {
+  con_default <- test_con("POSTGRES")
+  con_integer64 <- test_con("POSTGRES", bigint = "integer64")
+  con_integer <- test_con("POSTGRES", bigint = "integer")
+  con_numeric <- test_con("POSTGRES", bigint = "numeric")
+  con_character <- test_con("POSTGRES", bigint = "character")
+
+  dbWriteTable(con_default, "test", data.frame(a = 1:10L), field.types = c(a = "BIGINT"))
+  on.exit(dbRemoveTable(con_default, "test"))
+
+  expect_s3_class(dbReadTable(con_default, "test")$a, "integer64")
+  expect_s3_class(dbReadTable(con_integer64, "test")$a, "integer64")
+
+  expect_type(dbReadTable(con_integer, "test")$a, "integer")
+
+  expect_type(dbReadTable(con_numeric, "test")$a, "double")
+
+  expect_type(dbReadTable(con_character, "test")$a, "character")
+})
+
+# This test checks whether when writing to a table and using
+# result_describe_parameters to offer descriptions of the data
+# we are attempting to write, our logic remains robust to the
+# case when the data being written has columns ordered
+# differently than the table we are targetting.
+test_that("Writing data.frame with column ordering different than target table", {
+  tblName <- "test_order_write"
+  con <- test_con("POSTGRES")
+  values <- data.frame(
+    datetime = as.POSIXct(c(14, 15), origin = "2016-01-01", tz = "UTC"),
+    name = c("one", "two"),
+    num = 1:2,
+    stringsAsFactors = FALSE
+  )
+  sql <- sqlCreateTable(con, tblName, values)
+  dbExecute(con, sql)
+  on.exit(dbRemoveTable(con, tblName))
+  dbWriteTable(con, tblName, values[c(2, 3, 1)],
+    overwrite = FALSE, append = TRUE
+  )
+  received <- DBI::dbReadTable(con, tblName)
+  received <- received[order(received$num), ]
+  row.names(received) <- NULL
+  expect_equal(values, received)
+})
+
+test_that("odbcPreviewObject", {
+  tblName <- "test_preview"
+  con <- test_con("POSTGRES")
+  dbWriteTable(con, tblName, data.frame(a = 1:10L))
+  on.exit(dbRemoveTable(con, tblName))
+  # There should be no "Pending rows" warning
+  expect_no_warning({
+    res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)
+  })
+  expect_equal(nrow(res), 3)
+})
+

--- a/tests/testthat/test-driver-postgres.R
+++ b/tests/testthat/test-driver-postgres.R
@@ -140,9 +140,11 @@ test_that("Writing data.frame with column ordering different than target table",
     num = 1:2,
     stringsAsFactors = FALSE
   )
-  tbl <- local_table(con, "test_order_write", values)
+  tbl <- "test_order_write"
+  dbCreateTable(con, tbl, values)
+  dbAppendTable(con, tbl, values[c(2, 3, 1)])
+  on.exit(dbRemoveTable(con, tbl))
 
-  dbWriteTable(con, tbl, values[c(2, 3, 1)], overwrite = FALSE, append = TRUE)
   received <- dbReadTable(con, tbl)
   received <- received[order(received$num), ]
   row.names(received) <- NULL

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -177,6 +177,7 @@ test_that("blobs can be retrieved out of order", {
 })
 
 test_that("can bind NA values", {
+  con <- test_con("sqlserver")
   tblName <- "test_na"
   # With SELECT ing with the OEM SQL Server driver, everything
   # after the first column should be unbound. Test null detection for

--- a/tests/testthat/test-driver-sqlite.R
+++ b/tests/testthat/test-driver-sqlite.R
@@ -143,7 +143,7 @@ test_that("odbcPreviewObject works", {
 
   # There should be no "Pending rows" warning
   expect_no_warning({
-    res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)
+    res <- odbcPreviewObject(con, rowLimit = 3, table = tbl)
   })
   expect_equal(nrow(res), 3)
 })

--- a/tests/testthat/test-driver-sqlite.R
+++ b/tests/testthat/test-driver-sqlite.R
@@ -138,10 +138,9 @@ test_that("unsupported types gives informative error", {
 })
 
 test_that("odbcPreviewObject works", {
-  tblName <- "test_preview"
   con <- test_con("SQLITE")
-  dbWriteTable(con, tblName, data.frame(a = 1:10L))
-  on.exit(dbRemoveTable(con, tblName))
+  tbl <- local_table(con, "test_preview", data.frame(a = 1:10L))
+
   # There should be no "Pending rows" warning
   expect_no_warning({
     res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)

--- a/tests/testthat/test-driver-sqlite.R
+++ b/tests/testthat/test-driver-sqlite.R
@@ -128,25 +128,23 @@ test_that("SQLite", {
     "reexport", # TODO
     NULL
   ))
+})
 
+test_that("unsupported types gives informative error", {
+  con <- test_con("SQLITE")
 
-  local({
-    ## Test that trying to write unsupported types (like complex numbers) throws an
-    ## informative error message
-    con <- DBItest:::connect(DBItest:::get_default_context())
+  df <- data.frame(foo = complex(1))
+  expect_error(dbWriteTable(con, "df", df), "Column 'foo' is of unsupported type: 'complex'")
+})
 
-    df <- data.frame(foo = complex(1))
-    expect_error(dbWriteTable(con, "df", df), "Column 'foo' is of unsupported type: 'complex'")
+test_that("odbcPreviewObject works", {
+  tblName <- "test_preview"
+  con <- test_con("SQLITE")
+  dbWriteTable(con, tblName, data.frame(a = 1:10L))
+  on.exit(dbRemoveTable(con, tblName))
+  # There should be no "Pending rows" warning
+  expect_no_warning({
+    res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)
   })
-  test_that("odbcPreviewObject", {
-    tblName <- "test_preview"
-    con <- DBItest:::connect(DBItest:::get_default_context())
-    dbWriteTable(con, tblName, data.frame(a = 1:10L))
-    on.exit(dbRemoveTable(con, tblName))
-    # There should be no "Pending rows" warning
-    expect_no_warning({
-      res <- odbcPreviewObject(con, rowLimit = 3, table = tblName)
-    })
-    expect_equal(nrow(res), 3)
-  })
+  expect_equal(nrow(res), 3)
 })


### PR DESCRIPTION
* Add `test_con()` helper and move individual database tests into own blocks
* Add `local_table()` helper

Fixes #634