### PR TITLE
use Teradata-specific top-n syntax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # odbc (development version)
 
+* Teradata: Resolved issue when previewing tables using the Connections pane.
+
 # odbc 1.4.2
 
 * `dbAppendTable()` Improve performance by checking existence once (#691).

--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -293,6 +293,12 @@ odbcPreviewQuery.OdbcConnection <- function(connection, rowLimit, name) {
   paste0("SELECT TOP ", rowLimit, " * FROM ", name)
 }
 
+#' Teradata specific top-N syntax
+#' @rdname odbcPreviewQuery
+`odbcPreviewQuery.Teradata` <- function(connection, rowLimit, name) {
+  paste0("SELECT TOP ", rowLimit, " * FROM ", name)
+}
+
 #' Oracle specific top-N syntax
 #' @rdname odbcPreviewQuery
 odbcPreviewQuery.Oracle <- function(connection, rowLimit, name) {

--- a/man/odbcPreviewQuery.Rd
+++ b/man/odbcPreviewQuery.Rd
@@ -4,6 +4,7 @@
 \alias{odbcPreviewQuery}
 \alias{odbcPreviewQuery.OdbcConnection}
 \alias{odbcPreviewQuery.Microsoft SQL Server}
+\alias{odbcPreviewQuery.Teradata}
 \alias{odbcPreviewQuery.Oracle}
 \title{Create a preview query.}
 \usage{
@@ -12,6 +13,8 @@ odbcPreviewQuery(connection, rowLimit, name)
 \method{odbcPreviewQuery}{OdbcConnection}(connection, rowLimit, name)
 
 \method{odbcPreviewQuery}{`Microsoft SQL Server`}(connection, rowLimit, name)
+
+\method{odbcPreviewQuery}{Teradata}(connection, rowLimit, name)
 
 \method{odbcPreviewQuery}{Oracle}(connection, rowLimit, name)
 }


### PR DESCRIPTION
Internal support ticket reports errors when previewing tables from the Connections pane with Teradata:

```
Error in new_result(...):
expected something between the word 'TABLE_NAME' and the 'LIMIT' keyword.
```

Internally, odbc uses that LIMIT keyword when previewing tables for the Connections pane. Looks like Teradata [may need its own top-n syntax](https://stackoverflow.com/questions/59220900/r-dbplyr-sql-error-expecting-something-between-database-name-and-limit).
