### PR TITLE
remove call to `encodeString()` in `dbQuoteIdentifier()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 
 * Teradata: Resolved issue when previewing tables using the Connections pane.
 
+* The `"OdbcConnection"` method for `dbQuoteIdentifier()` will no longer 
+  pass `x` to `encodeString()` before returning, for consistency with the
+  default implementation in DBI (@simonpcouch, #765).
 
 # odbc 1.4.2
 

--- a/R/dbi-connection.R
+++ b/R/dbi-connection.R
@@ -154,7 +154,7 @@ setMethod("dbQuoteIdentifier", c("OdbcConnection", "character"),
       x <- gsub(conn@quote, paste0(conn@quote, conn@quote), x, fixed = TRUE)
     }
     nms <- names(x)
-    res <- DBI::SQL(paste(conn@quote, encodeString(x), conn@quote, sep = ""))
+    res <- DBI::SQL(paste(conn@quote, x, conn@quote, sep = ""))
     names(res) <- nms
     res
   }


### PR DESCRIPTION
Closes #497.

The [odbc commit that originally introduced `encodeString()`](https://github.com/r-dbi/odbc/commit/b22b0d5fb75d479684cc51495560ad157f52d863) in 2016 noted that the change was for consistency with DBI. In 2017, DBI [removed the call to `encodeString()`](https://github.com/r-dbi/DBI/commit/2e904e7245023ba49ce6394406f9054ac6e15fb3).