### PR TITLE
nanodbc: include <limits> header

### DIFF
--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <ctime>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <type_traits>
 


### PR DESCRIPTION
Fixes build when using
```
docker@e43a36960e74:~/odbc$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/11/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:amdgcn-amdhsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: <snip>
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 11.3.0 (Debian 11.3.0-3)
```

Issue:

```
   nanodbc/nanodbc.cpp: In member function ‘long int nanodbc::statement::statement_impl::affected_rows() const’:
   nanodbc/nanodbc.cpp:1817:57: error: ‘numeric_limits’ is not a member of ‘std’
    1817 |         NANODBC_ASSERT(rows <= static_cast<SQLLEN>(std::numeric_limits<long>::max()));
```

Compare to [upstream](https://github.com/nanodbc/nanodbc/blob/main/nanodbc/nanodbc.cpp#L26).