### PR TITLE
remove redundant row limit in table preview

### DIFF
--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -262,9 +262,7 @@ odbcPreviewObject.OdbcConnection <- function(connection,
     name <- paste(dbQuoteIdentifier(connection, catalog), name, sep = ".")
   }
 
-  dbGetQuery(connection, odbcPreviewQuery(connection, rowLimit, name),
-    n = rowLimit
-  )
+  dbGetQuery(connection, odbcPreviewQuery(connection, rowLimit, name))
 }
 
 #' Create a preview query.


### PR DESCRIPTION
I'm not sure why it is that we pass `rowLimit` both to `odbcPreviewQuery()` and `dbGetQuery()`? Introduced in https://github.com/r-dbi/odbc/commit/111cedfe2aacb1ca4f87016814fb7d295f7dfb3f. From my understanding, `odbcPreviewQuery()` should limit the number of rows returned effectively and we can leave `dbGetQuery(n)` as its default value, `-1`, which will be passed to `dbFetch()` and interpreted as "return all available rows." 

Closes #142, possibly; I wonder if Redshift trips up on a `dbFetch(n)` value greater than what the query actually returns. I don't have a Redshift account set up for myself but will ask the customer to test.

EDIT: if this does do the trick, we could split this change off into a Redshift method so that it doesn't apply to other DBMS.