### PR TITLE
use Redshift-specific top n syntax

### DIFF
--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -293,6 +293,12 @@ odbcPreviewQuery.OdbcConnection <- function(connection, rowLimit, name) {
   paste0("SELECT TOP ", rowLimit, " * FROM ", name)
 }
 
+#' Redshift specific top-N syntax
+#' @rdname odbcPreviewQuery
+`odbcPreviewQuery.Redshift` <- function(connection, rowLimit, name) {
+  paste0("SELECT TOP ", rowLimit, " * FROM ", name)
+}
+
 #' Teradata specific top-N syntax
 #' @rdname odbcPreviewQuery
 `odbcPreviewQuery.Teradata` <- function(connection, rowLimit, name) {

--- a/man/odbcPreviewQuery.Rd
+++ b/man/odbcPreviewQuery.Rd
@@ -4,6 +4,7 @@
 \alias{odbcPreviewQuery}
 \alias{odbcPreviewQuery.OdbcConnection}
 \alias{odbcPreviewQuery.Microsoft SQL Server}
+\alias{odbcPreviewQuery.Redshift}
 \alias{odbcPreviewQuery.Teradata}
 \alias{odbcPreviewQuery.Oracle}
 \title{Create a preview query.}
@@ -13,6 +14,8 @@ odbcPreviewQuery(connection, rowLimit, name)
 \method{odbcPreviewQuery}{OdbcConnection}(connection, rowLimit, name)
 
 \method{odbcPreviewQuery}{`Microsoft SQL Server`}(connection, rowLimit, name)
+
+\method{odbcPreviewQuery}{Redshift}(connection, rowLimit, name)
 
 \method{odbcPreviewQuery}{Teradata}(connection, rowLimit, name)
 


### PR DESCRIPTION
The solution for ticket 98494 may be this simple; possibly fixes a connections pane crash with Redshift.

The following code, which is run internally by the connections pane, crashes when ran from the console:

```r
odbc::dbGetQuery(con, odbc:::`odbcPreviewQuery.OdbcConnection`(con, 10, name = table.name))
```

Strangely, only for some tables.

This (which uses the `TOP` rather than `LIMIT` syntaxes) returns the intended values:

```r
odbc::dbGetQuery(con, odbc:::`odbcPreviewQuery.Microsoft SQL Server`(con, 10, name = table.name))
```

Some resources online say either `TOP` and `LIMIT` should work, and the [Amazon docs](https://docs.aws.amazon.com/redshift/latest/dg/r_SELECT_list.html) read "The behavior with the TOP clause is the same as the behavior with the LIMIT clause," though also notes that `TOP` and `LIMIT` can't be mixed. 

GitHub is blocked by their firewall, so we'll send them source and have them build locally. Leaving as draft until then.