### PR TITLE
include synonyms in `odbcListObjects()` output

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(odbcListColumns,OdbcConnection)
 S3method(odbcListObjectTypes,default)
+S3method(odbcListObjects,"Microsoft SQL Server")
 S3method(odbcListObjects,OdbcConnection)
 S3method(odbcPreviewObject,OdbcConnection)
 export(databricks)

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 * The `"OdbcConnection"` method for `dbQuoteIdentifier()` will no longer 
   pass `x` to `encodeString()` before returning, for consistency with the
   default implementation in DBI (@simonpcouch, #765).
+  
+* The Connections pane will now include synonyms when displaying objects with
+  Microsoft SQL Server (@simonpcouch, #773).
 
 # odbc 1.4.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,9 @@
   pass `x` to `encodeString()` before returning, for consistency with the
   default implementation in DBI (@simonpcouch, #765).
   
-* The Connections pane will now include synonyms when displaying objects with
-  Microsoft SQL Server (@simonpcouch, #773).
+* `dbListTables()`, `dbExistsTable()`, and `odbcListObjects()` now support
+  synonyms with Microsoft SQL Server. This also means that users can now
+  interact with synonyms using the Connections pane (@simonpcouch, #773).
 
 # odbc 1.4.2
 

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -260,6 +260,10 @@ synonyms_query <- function(conn, catalog_name = NULL, schema_name = NULL) {
   has_catalog <- !is.null(catalog_name)
   has_schema <- !is.null(schema_name)
 
+  if (!has_catalog & !has_schema) {
+    return(paste0(res, " WHERE ", filter_is_table))
+  }
+
   if (has_catalog & has_schema) {
     res <- paste0(res, " WHERE DB.name = '", catalog_name, "' AND Sch.name = '", schema_name, "'")
   } else if (has_catalog) {
@@ -268,5 +272,7 @@ synonyms_query <- function(conn, catalog_name = NULL, schema_name = NULL) {
     res <- paste0(res, " WHERE Sch.name = '", schema_name, "'")
   }
 
-  paste0(res, " AND OBJECTPROPERTY(Object_ID(Syn.base_object_name), 'IsTable') = 1;")
+  paste0(res, " AND ", filter_is_table)
 }
+
+filter_is_table <- "OBJECTPROPERTY(Object_ID(Syn.base_object_name), 'IsTable') = 1;"

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -73,11 +73,11 @@ setMethod("dbExistsTable", c("Microsoft SQL Server", "character"),
     stopifnot(length(name) == 1)
     if (isTempTable(conn, name, ...)) {
       query <- paste0("SELECT OBJECT_ID('tempdb..", name, "')")
-      !is.na(dbGetQuery(conn, query)[[1]])
-    } else {
-      df <- odbcConnectionTables(conn, name = name, ...)
-      NROW(df) > 0
+      return(!is.na(dbGetQuery(conn, query)[[1]]))
     }
+    df <- odbcConnectionTables(conn, name = name, ...)
+    synonyms <- dbGetQuery(conn, synonyms_query(conn, ...))
+    NROW(df) > 0 || name %in% synonyms$name
   }
 )
 

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -234,6 +234,10 @@ setMethod("odbcDataType", "Microsoft SQL Server",
     ...
   )
 
+  if (!any(objects$type == "table")) {
+    return(objects)
+  }
+
   synonyms <- dbGetQuery(connection, synonyms_query(connection, catalog, schema))
 
   if (!is.null(name)) {

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -234,7 +234,7 @@ setMethod("odbcDataType", "Microsoft SQL Server",
     ...
   )
 
-  if (!any(objects$type == "table")) {
+  if (!any(objects$type == "table") && nrow(objects) > 0) {
     return(objects)
   }
 

--- a/man/SQLServer.Rd
+++ b/man/SQLServer.Rd
@@ -12,6 +12,7 @@
 \alias{dbExistsTable,Microsoft SQL Server,SQL-method}
 \alias{odbcConnectionSchemas,Microsoft SQL Server-method}
 \alias{sqlCreateTable,Microsoft SQL Server-method}
+\alias{odbcListObjects.Microsoft SQL Server}
 \title{SQL Server}
 \description{
 Details of SQL Server methods for odbc and DBI generics.
@@ -57,6 +58,11 @@ sure we list the schemas in the appropriate database/catalog.
 
 Warns if \code{temporary = TRUE} but the \code{name} does not conform to temp table
 naming conventions (i.e. it doesn't start with \verb{#}).
+}
+
+\subsection{\code{odbcListObjects()}}{
+
+This method makes tables that are synonyms visible in the Connections pane.
 }
 }
 \keyword{internal}

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -357,16 +357,27 @@ test_that("odbcListObjects shows synonyms (#221)", {
 
   dbExecute(con, "CREATE SYNONYM testSchema.tbl2 for testSchema.tbl")
   expect_equal(nrow(odbcListObjects(con, catalog = db, schema = "testSchema")), 2)
+  expect_length(dbListTables(con, catalog_name = db, schema_name = "testSchema"), 2)
   expect_equal(
     nrow(odbcListObjects(con, catalog = db, schema = "testSchema", name = "tbl")),
     1
   )
   expect_false("tbl2" %in% odbcListObjects(con))
+  expect_true(
+    dbExistsTable(con, name = "tbl2", catalog_name = db, schema_name = "testSchema")
+  )
+  expect_true(dbExistsTable(con, name = Id(db, "testSchema", "tbl2")))
   dbExecute(con, "DROP SYNONYM testSchema.tbl2")
+  expect_false(dbExistsTable(con, name = Id(db, "testSchema", "tbl2")))
 
   # ensure query filters out synonyms in schemas other than the one
   # where the base object lives effectively
   dbExecute(con, "CREATE SYNONYM testSchema2.tbl2 for testSchema.tbl")
   expect_equal(nrow(odbcListObjects(con, catalog = db, schema = "testSchema")), 1)
   expect_equal(nrow(odbcListObjects(con, catalog = db, schema = "testSchema2")), 1)
+  expect_length(dbListTables(con, catalog_name = db, schema_name = "testSchema2"), 1)
+  expect_true(
+    dbExistsTable(con, name = "tbl2", catalog_name = db, schema_name = "testSchema2")
+  )
+  expect_true(dbExistsTable(con, name = Id(db, "testSchema2", "tbl2")))
 })

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -362,7 +362,8 @@ test_that("odbcListObjects shows synonyms (#221)", {
     nrow(odbcListObjects(con, catalog = db, schema = "testSchema", name = "tbl")),
     1
   )
-  expect_false("tbl2" %in% odbcListObjects(con))
+  expect_false("tbl2" %in% odbcListObjects(con)$name)
+  expect_false("tbl2" %in% odbcListObjects(con, catalog = db)$name)
   expect_true(
     dbExistsTable(con, name = "tbl2", catalog_name = db, schema_name = "testSchema")
   )

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -367,6 +367,9 @@ test_that("odbcListObjects shows synonyms (#221)", {
     dbExistsTable(con, name = "tbl2", catalog_name = db, schema_name = "testSchema")
   )
   expect_true(dbExistsTable(con, name = Id(db, "testSchema", "tbl2")))
+  expect_true(dbExistsTable(con, name = Id("testSchema", "tbl2")))
+  expect_true(dbExistsTable(con, name = Id("tbl2")))
+  expect_true(dbExistsTable(con, name = "tbl2"))
   dbExecute(con, "DROP SYNONYM testSchema.tbl2")
   expect_false(dbExistsTable(con, name = Id(db, "testSchema", "tbl2")))
 


### PR DESCRIPTION
Closes #221.

This PR modifies/adds SQL Server methods for `dbListTables()`, `dbExistsTable()`, and `odbcListObjects()` that include synonyms in output. This also means that synonyms will show up in the Connections pane.

~~Note that this PR makes no changes to `dbListTables()`, which is noted in the original issue.~~

[EDITs: update PR scope]