### PR TITLE
connections-pane: infer hierarchy more efficienty

### DIFF
--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -44,15 +44,13 @@ odbcListObjectTypes.default <- function(connection) {
     obj_types <- c(obj_types, list(view = list(contains = "data")))
   }
 
-  # check for multiple schema or a named schema
-  schemas <- string_values(odbcConnectionSchemas(connection))
-  if (length(schemas) > 0) {
+  # check for schema support
+  if (conn@info$supports.schema) {
     obj_types <- list(schema = list(contains = obj_types))
   }
 
   # check for multiple catalogs
-  catalogs <- string_values(odbcConnectionCatalogs(connection))
-  if (length(catalogs) > 0) {
+  if (conn@info$supports.catalogs) {
     obj_types <- list(catalog = list(contains = obj_types))
   }
 

--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -45,7 +45,7 @@ odbcListObjectTypes.default <- function(connection) {
   }
 
   # check for schema support
-  if (conn@info$supports.schema) {
+  if (connection@info$supports.schema) {
     obj_types <- list(schema = list(contains = obj_types))
   }
 

--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -50,7 +50,7 @@ odbcListObjectTypes.default <- function(connection) {
   }
 
   # check for multiple catalogs
-  if (conn@info$supports.catalogs) {
+  if (connection@info$supports.catalogs) {
     obj_types <- list(catalog = list(contains = obj_types))
   }
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -76,11 +76,15 @@ std::string get_info_or_empty(connection_ptr const& p, short type) {
 // [[Rcpp::export]]
 Rcpp::List connection_info(connection_ptr const& p) {
   SQLUINTEGER getdata_ext;
+  SQLUINTEGER owner_usage;
   try {
     getdata_ext =
         (*p)->connection()->get_info<SQLUINTEGER>(SQL_GETDATA_EXTENSIONS);
+    owner_usage =
+        (*p)->connection()->get_info<SQLUINTEGER>(SQL_OWNER_USAGE);
   } catch (const nanodbc::database_error& c) {
     getdata_ext = 0;
+    owner_usage = 0;
   }
 
   return Rcpp::List::create(
@@ -97,6 +101,8 @@ Rcpp::List connection_info(connection_ptr const& p) {
       Rcpp::_["driver.version"] = get_info_or_empty(p, SQL_DRIVER_VER),
       Rcpp::_["odbcdriver.version"] = get_info_or_empty(p, SQL_DRIVER_ODBC_VER),
       Rcpp::_["supports.transactions"] = (*p)->supports_transactions(),
+      Rcpp::_["supports.catalogs"] = get_info_or_empty(p, SQL_CATALOG_NAME) == "Y" ? true : false,
+      Rcpp::_["supports.schema"] = owner_usage == 0 ? false : true,
       Rcpp::_["getdata.extensions.any_column"] =
           ((getdata_ext & SQL_GD_ANY_COLUMN) != 0),
       Rcpp::_["getdata.extensions.any_order"] =

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -81,7 +81,7 @@ Rcpp::List connection_info(connection_ptr const& p) {
     getdata_ext =
         (*p)->connection()->get_info<SQLUINTEGER>(SQL_GETDATA_EXTENSIONS);
     owner_usage =
-        (*p)->connection()->get_info<SQLUINTEGER>(SQL_OWNER_USAGE);
+        (*p)->connection()->get_info<SQLUINTEGER>(SQL_SCHEMA_USAGE);
   } catch (const nanodbc::database_error& c) {
     getdata_ext = 0;
     owner_usage = 0;


### PR DESCRIPTION
This should lighten the usage of the ( sometimes expensive ) `SQLTables` API call to infer the DB hierarchy when connecting.

Over time, and if/when needed, we could also make the DB hierarchy static and encode the per-back-end structure in the package.

[Documentation on the attributes](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetinfo-function?view=sql-server-ver16).

Closes https://github.com/r-dbi/odbc/issues/714 and hopefully fixes https://github.com/r-dbi/odbc/issues/606.