### PR TITLE
check inputs with rlang type checkers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     lifecycle,
     methods,
     Rcpp (>= 0.12.11),
-    rlang (>= 0.2.0)
+    rlang (>= 1.1.0)
 Suggests:
     covr,
     DBItest,
@@ -75,6 +75,8 @@ Collate:
     'driver-sqlite.R'
     'driver-teradata.R'
     'driver-vertica.R'
+    'import-standalone-obj-type.R'
+    'import-standalone-types-check.R'
     'odbc-config.R'
     'odbc-data-sources.R'
     'odbc-drivers.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Depends:
 Imports:
     bit64,
     blob (>= 1.2.0),
+    cli,
     DBI (>= 1.0.0),
     hms,
     lifecycle,

--- a/R/dbi-connection.R
+++ b/R/dbi-connection.R
@@ -191,10 +191,10 @@ setMethod("dbListTables", "OdbcConnection",
            table_name = NULL,
            table_type = NULL,
            ...) {
-    check_string(catalog_name, allow_na = TRUE, allow_null = TRUE)
-    check_string(schema_name, allow_na = TRUE, allow_null = TRUE)
-    check_string(table_name, allow_na = TRUE, allow_null = TRUE)
-    check_string(table_type, allow_na = TRUE, allow_null = TRUE)
+    check_string(catalog_name, allow_null = TRUE)
+    check_string(schema_name, allow_null = TRUE)
+    check_string(table_name, allow_null = TRUE)
+    check_string(table_type, allow_null = TRUE)
 
     tables <- odbcConnectionTables(
       conn,

--- a/R/dbi-connection.R
+++ b/R/dbi-connection.R
@@ -191,6 +191,11 @@ setMethod("dbListTables", "OdbcConnection",
            table_name = NULL,
            table_type = NULL,
            ...) {
+    check_string(catalog_name, allow_na = TRUE, allow_null = TRUE)
+    check_string(schema_name, allow_na = TRUE, allow_null = TRUE)
+    check_string(table_name, allow_na = TRUE, allow_null = TRUE)
+    check_string(table_type, allow_na = TRUE, allow_null = TRUE)
+
     tables <- odbcConnectionTables(
       conn,
       name = table_name,

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -168,18 +168,18 @@ setMethod("dbConnect", "OdbcDriver",
       dbms.name = NULL,
       attributes = NULL,
       .connection_string = NULL) {
-    check_string(dsn, allow_na = TRUE, allow_null = TRUE)
-    check_string(timezone, allow_na = TRUE, allow_null = TRUE)
-    check_string(timezone_out, allow_na = TRUE, allow_null = TRUE)
-    check_string(encoding, allow_na = TRUE, allow_null = TRUE)
+    check_string(dsn, allow_null = TRUE)
+    check_string(timezone, allow_null = TRUE)
+    check_string(timezone_out, allow_null = TRUE)
+    check_string(encoding, allow_null = TRUE)
     arg_match(bigint)
     check_number_decimal(timeout, allow_null = TRUE, allow_na = TRUE)
-    check_string(driver, allow_na = TRUE, allow_null = TRUE)
-    check_string(server, allow_na = TRUE, allow_null = TRUE)
-    check_string(database, allow_na = TRUE, allow_null = TRUE)
-    check_string(uid, allow_na = TRUE, allow_null = TRUE)
-    check_string(pwd, allow_na = TRUE, allow_null = TRUE)
-    check_string(dbms.name, allow_na = TRUE, allow_null = TRUE)
+    check_string(driver, allow_null = TRUE)
+    check_string(server, allow_null = TRUE)
+    check_string(database, allow_null = TRUE)
+    check_string(uid, allow_null = TRUE)
+    check_string(pwd, allow_null = TRUE)
+    check_string(dbms.name, allow_null = TRUE)
 
     con <- OdbcConnection(
       dsn = dsn,

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -172,7 +172,7 @@ setMethod("dbConnect", "OdbcDriver",
     check_string(timezone, allow_na = TRUE, allow_null = TRUE)
     check_string(timezone_out, allow_na = TRUE, allow_null = TRUE)
     check_string(encoding, allow_na = TRUE, allow_null = TRUE)
-    check_character(bigint, allow_na = TRUE, allow_null = TRUE)
+    arg_match(bigint)
     check_number_decimal(timeout, allow_null = TRUE, allow_na = TRUE)
     check_string(driver, allow_na = TRUE, allow_null = TRUE)
     check_string(server, allow_na = TRUE, allow_null = TRUE)

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -168,6 +168,19 @@ setMethod("dbConnect", "OdbcDriver",
       dbms.name = NULL,
       attributes = NULL,
       .connection_string = NULL) {
+    check_string(dsn, allow_na = TRUE, allow_null = TRUE)
+    check_string(timezone, allow_na = TRUE, allow_null = TRUE)
+    check_string(timezone_out, allow_na = TRUE, allow_null = TRUE)
+    check_string(encoding, allow_na = TRUE, allow_null = TRUE)
+    check_character(bigint, allow_na = TRUE, allow_null = TRUE)
+    check_number_decimal(timeout, allow_null = TRUE, allow_na = TRUE)
+    check_string(driver, allow_na = TRUE, allow_null = TRUE)
+    check_string(server, allow_na = TRUE, allow_null = TRUE)
+    check_string(database, allow_na = TRUE, allow_null = TRUE)
+    check_string(uid, allow_na = TRUE, allow_null = TRUE)
+    check_string(pwd, allow_na = TRUE, allow_null = TRUE)
+    check_string(dbms.name, allow_na = TRUE, allow_null = TRUE)
+
     con <- OdbcConnection(
       dsn = dsn,
       ...,

--- a/R/dbi-table.R
+++ b/R/dbi-table.R
@@ -285,6 +285,11 @@ setMethod("dbListFields", c("OdbcConnection", "character"),
            schema_name = NULL,
            column_name = NULL,
            ...) {
+    check_string(name)
+    check_string(catalog_name, allow_na = TRUE, allow_null = TRUE)
+    check_string(schema_name, allow_na = TRUE, allow_null = TRUE)
+    check_string(column_name, allow_na = TRUE, allow_null = TRUE)
+
     cols <- odbcConnectionColumns_(
       conn,
       name = name,

--- a/R/dbi-table.R
+++ b/R/dbi-table.R
@@ -300,9 +300,9 @@ setMethod("dbListFields", c("OdbcConnection", "character"),
            column_name = NULL,
            ...) {
     check_string(name)
-    check_string(catalog_name, allow_na = TRUE, allow_null = TRUE)
-    check_string(schema_name, allow_na = TRUE, allow_null = TRUE)
-    check_string(column_name, allow_na = TRUE, allow_null = TRUE)
+    check_string(catalog_name, allow_null = TRUE)
+    check_string(schema_name, allow_null = TRUE)
+    check_string(column_name, allow_null = TRUE)
 
     cols <- odbcConnectionColumns_(
       conn,

--- a/R/dbi-table.R
+++ b/R/dbi-table.R
@@ -39,32 +39,29 @@ odbc_write_table <- function(conn,
                              row.names = NULL,
                              field.types = NULL,
                              batch_rows = getOption("odbc.batch_rows", NA),
-                             ...,
-                             call = rlang::caller_env()) {
-  check_bool(overwrite, call = call)
-  check_bool(append, call = call)
-  check_bool(temporary, call = call)
+                             ...) {
+  check_bool(overwrite)
+  check_bool(append)
+  check_bool(temporary)
   check_number_whole(batch_rows, allow_na = TRUE, allow_null = TRUE)
-  check_row.names(row.names, call = call)
-  check_field.types(field.types, call = call)
+  check_row.names(row.names)
+  check_field.types(field.types)
   if (append && !is.null(field.types)) {
     cli::cli_abort(
-      "Cannot specify {.arg field.types} with {.code append = TRUE}.",
-      call = call
+      "Cannot specify {.arg field.types} with {.code append = TRUE}."
     )
   }
   if (overwrite && append) {
     cli::cli_abort(
-      "{.arg overwrite} and {.arg append} cannot both be {.val TRUE}.",
-      call = call
+      "{.arg overwrite} and {.arg append} cannot both be {.val TRUE}."
     )
   }
 
   found <- dbExistsTableForWrite(conn, name)
   if (found && !overwrite && !append) {
-    rlang::abort("Table ", toString(name), " exists in database, and both overwrite and",
-      " append are FALSE",
-      call = call
+    cli::cli_abort(
+      "Table {toString(name)} exists in database, and both overwrite and \\
+       append are {.code FALSE}."
     )
   }
   if (found && overwrite) {
@@ -131,8 +128,7 @@ setMethod("dbAppendTable", "OdbcConnection",
     if (!is.null(row.names)) {
       cli::cli_abort(
         "{.arg row.names} must be {.code NULL}, not \\
-         {.obj_type_friendly {row.names}}.",
-        call = current_env()
+         {.obj_type_friendly {row.names}}."
       )
     }
 

--- a/R/dbi-table.R
+++ b/R/dbi-table.R
@@ -39,27 +39,32 @@ odbc_write_table <- function(conn,
                              row.names = NULL,
                              field.types = NULL,
                              batch_rows = getOption("odbc.batch_rows", NA),
-                             ...) {
-  # Sanity checks: begin
-  stopifnot(
-    rlang::is_scalar_logical(overwrite) && !is.na(overwrite),
-    rlang::is_scalar_logical(append) && !is.na(append),
-    rlang::is_scalar_logical(temporary) && !is.na(temporary),
-    rlang::is_null(field.types) || (rlang::is_named(field.types))
-  )
+                             ...,
+                             call = rlang::caller_env()) {
+  check_bool(overwrite, call = call)
+  check_bool(append, call = call)
+  check_bool(temporary, call = call)
+  check_number_whole(batch_rows, allow_na = TRUE, allow_null = TRUE)
+  check_row.names(row.names, call = call)
+  check_field.types(field.types, call = call)
   if (append && !is.null(field.types)) {
-    stop("Cannot specify field.types with append = TRUE", call. = FALSE)
+    cli::cli_abort(
+      "Cannot specify {.arg field.types} with {.code append = TRUE}.",
+      call = call
+    )
   }
   if (overwrite && append) {
-    stop("overwrite and append cannot both be TRUE", call. = FALSE)
+    cli::cli_abort(
+      "{.arg overwrite} and {.arg append} cannot both be {.val TRUE}.",
+      call = call
+    )
   }
-  # Sanity checks: done
 
   found <- dbExistsTableForWrite(conn, name)
   if (found && !overwrite && !append) {
-    stop("Table ", toString(name), " exists in database, and both overwrite and",
+    rlang::abort("Table ", toString(name), " exists in database, and both overwrite and",
       " append are FALSE",
-      call. = FALSE
+      call = call
     )
   }
   if (found && overwrite) {
@@ -123,7 +128,13 @@ setMethod("dbAppendTable", "OdbcConnection",
   function(conn, name, value,
            batch_rows = getOption("odbc.batch_rows", NA),
            ..., row.names = NULL) {
-    stopifnot(is.null(row.names))
+    if (!is.null(row.names)) {
+      cli::cli_abort(
+        "{.arg row.names} must be {.code NULL}, not \\
+         {.obj_type_friendly {row.names}}.",
+        call = current_env()
+      )
+    }
 
     fieldDetails <- tryCatch({
       details <- odbcConnectionColumns_(conn, name, exact = TRUE)
@@ -213,6 +224,9 @@ setMethod("sqlCreateTable", "OdbcConnection",
            temporary = FALSE,
            ...,
            field.types = NULL) {
+    check_bool(temporary)
+    check_row.names(row.names)
+    check_field.types(field.types)
     table <- dbQuoteIdentifier(con, table)
     fields <- createFields(con, fields, field.types, row.names)
 

--- a/R/dbi-table.R
+++ b/R/dbi-table.R
@@ -40,7 +40,7 @@ odbc_write_table <- function(conn,
                              field.types = NULL,
                              batch_rows = getOption("odbc.batch_rows", NA),
                              ...) {
-  call <- call2("dbWriteTable")
+  call <- caller_env()
   check_bool(overwrite, call = call)
   check_bool(append, call = call)
   check_bool(temporary, call = call)

--- a/R/dbi-table.R
+++ b/R/dbi-table.R
@@ -40,20 +40,23 @@ odbc_write_table <- function(conn,
                              field.types = NULL,
                              batch_rows = getOption("odbc.batch_rows", NA),
                              ...) {
-  check_bool(overwrite)
-  check_bool(append)
-  check_bool(temporary)
-  check_number_whole(batch_rows, allow_na = TRUE, allow_null = TRUE)
-  check_row.names(row.names)
-  check_field.types(field.types)
+  call <- call2("dbWriteTable")
+  check_bool(overwrite, call = call)
+  check_bool(append, call = call)
+  check_bool(temporary, call = call)
+  check_number_whole(batch_rows, allow_na = TRUE, allow_null = TRUE, call = call)
+  check_row.names(row.names, call = call)
+  check_field.types(field.types, call = call)
   if (append && !is.null(field.types)) {
     cli::cli_abort(
-      "Cannot specify {.arg field.types} with {.code append = TRUE}."
+      "Cannot specify {.arg field.types} with {.code append = TRUE}.",
+      call = call
     )
   }
   if (overwrite && append) {
     cli::cli_abort(
-      "{.arg overwrite} and {.arg append} cannot both be {.val TRUE}."
+      "{.arg overwrite} and {.arg append} cannot both be {.val TRUE}.",
+      call = call
     )
   }
 
@@ -61,7 +64,8 @@ odbc_write_table <- function(conn,
   if (found && !overwrite && !append) {
     cli::cli_abort(
       "Table {toString(name)} exists in database, and both overwrite and \\
-       append are {.code FALSE}."
+       append are {.code FALSE}.",
+      call = call
     )
   }
   if (found && overwrite) {

--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -66,13 +66,13 @@ setMethod("dbConnect", "DatabricksOdbcDriver",
            ...) {
     # For backward compatibility with RStudio connection string
     check_exclusive(httpPath, HTTPPath)
-    check_string(httpPath, allow_na = TRUE, allow_null = TRUE)
-    check_string(workspace, allow_na = TRUE, allow_null = TRUE)
+    check_string(httpPath, allow_null = TRUE)
+    check_string(workspace, allow_null = TRUE)
     check_bool(useNativeQuery)
-    check_string(driver, allow_na = TRUE, allow_null = TRUE)
-    check_string(HTTPPath, allow_na = TRUE, allow_null = TRUE)
-    check_string(uid, allow_na = TRUE, allow_null = TRUE)
-    check_string(pwd, allow_na = TRUE, allow_null = TRUE)
+    check_string(driver, allow_null = TRUE)
+    check_string(HTTPPath, allow_null = TRUE)
+    check_string(uid, allow_null = TRUE)
+    check_string(pwd, allow_null = TRUE)
 
     args <- databricks_args(
       httpPath = if (missing(httpPath)) HTTPPath else httpPath,

--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -66,6 +66,13 @@ setMethod("dbConnect", "DatabricksOdbcDriver",
            ...) {
     # For backward compatibility with RStudio connection string
     check_exclusive(httpPath, HTTPPath)
+    check_string(httpPath, allow_na = TRUE, allow_null = TRUE)
+    check_string(workspace, allow_na = TRUE, allow_null = TRUE)
+    check_logical(useNativeQuery)
+    check_string(driver, allow_na = TRUE, allow_null = TRUE)
+    check_string(HTTPPath, allow_na = TRUE, allow_null = TRUE)
+    check_string(uid, allow_na = TRUE, allow_null = TRUE)
+    check_string(pwd, allow_na = TRUE, allow_null = TRUE)
 
     args <- databricks_args(
       httpPath = if (missing(httpPath)) HTTPPath else httpPath,

--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -68,7 +68,7 @@ setMethod("dbConnect", "DatabricksOdbcDriver",
     check_exclusive(httpPath, HTTPPath)
     check_string(httpPath, allow_na = TRUE, allow_null = TRUE)
     check_string(workspace, allow_na = TRUE, allow_null = TRUE)
-    check_logical(useNativeQuery)
+    check_bool(useNativeQuery)
     check_string(driver, allow_na = TRUE, allow_null = TRUE)
     check_string(HTTPPath, allow_na = TRUE, allow_null = TRUE)
     check_string(uid, allow_na = TRUE, allow_null = TRUE)

--- a/R/driver-db2.R
+++ b/R/driver-db2.R
@@ -15,6 +15,9 @@ setMethod("sqlCreateTable", "DB2/AIX64",
            temporary = FALSE,
            ...,
            field.types = NULL) {
+    check_bool(temporary)
+    check_row.names(row.names)
+    check_field.types(field.types)
     table <- dbQuoteIdentifier(con, table)
     fields <- createFields(con, fields, field.types, row.names)
 

--- a/R/driver-hana.R
+++ b/R/driver-hana.R
@@ -14,6 +14,9 @@ setMethod("sqlCreateTable", "HDB",
            temporary = FALSE,
            ...,
            field.types = NULL) {
+    check_bool(temporary)
+    check_row.names(row.names)
+    check_field.types(field.types)
     table <- dbQuoteIdentifier(con, table)
     fields <- createFields(con, fields, field.types, row.names)
 

--- a/R/driver-oracle.R
+++ b/R/driver-oracle.R
@@ -20,6 +20,9 @@ setMethod("sqlCreateTable", "Oracle",
            temporary = FALSE,
            ...,
            field.types = NULL) {
+    check_bool(temporary)
+    check_row.names(row.names)
+    check_field.types(field.types)
     table <- dbQuoteIdentifier(con, table)
     fields <- createFields(con, fields, field.types, row.names)
 

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -179,8 +179,13 @@ setMethod("sqlCreateTable", "Microsoft SQL Server",
            temporary = FALSE,
            ...,
            field.types = NULL) {
+    check_bool(temporary)
+    check_row.names(row.names)
+    check_field.types(field.types)
     if (temporary && !isTempTable(con, table)) {
-      warning("Temporary flag is set to true, but table name doesn't use # prefix")
+      cli::cli_warn(
+        "{.arg temporary} is {.code TRUE}, but table name doesn't use # prefix."
+      )
     }
     temporary <- FALSE
     callNextMethod()

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -95,10 +95,10 @@ setMethod("dbListTables", "Microsoft SQL Server",
            table_name = NULL,
            table_type = NULL,
            ...) {
-    check_string(catalog_name, allow_na = TRUE, allow_null = TRUE)
-    check_string(schema_name, allow_na = TRUE, allow_null = TRUE)
-    check_string(table_name, allow_na = TRUE, allow_null = TRUE)
-    check_string(table_type, allow_na = TRUE, allow_null = TRUE)
+    check_string(catalog_name, allow_null = TRUE)
+    check_string(schema_name, allow_null = TRUE)
+    check_string(table_name, allow_null = TRUE)
+    check_string(table_type, allow_null = TRUE)
 
     res <- callNextMethod()
 

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -95,6 +95,11 @@ setMethod("dbListTables", "Microsoft SQL Server",
            table_name = NULL,
            table_type = NULL,
            ...) {
+    check_string(catalog_name, allow_na = TRUE, allow_null = TRUE)
+    check_string(schema_name, allow_na = TRUE, allow_null = TRUE)
+    check_string(table_name, allow_na = TRUE, allow_null = TRUE)
+    check_string(table_type, allow_na = TRUE, allow_null = TRUE)
+
     res <- callNextMethod()
 
     if (is.null(catalog_name) && is.null(schema_name)) {

--- a/R/driver-teradata.R
+++ b/R/driver-teradata.R
@@ -14,6 +14,9 @@ setMethod("sqlCreateTable", "Teradata",
            temporary = FALSE,
            ...,
            field.types = NULL) {
+    check_bool(temporary)
+    check_row.names(row.names)
+    check_field.types(field.types)
     table <- dbQuoteIdentifier(con, table)
     fields <- createFields(con, fields, field.types, row.names)
 

--- a/R/import-standalone-obj-type.R
+++ b/R/import-standalone-obj-type.R
@@ -1,0 +1,360 @@
+# Standalone file: do not edit by hand
+# Source: <https://github.com/r-lib/rlang/blob/main/R/standalone-obj-type.R>
+# ----------------------------------------------------------------------
+#
+# ---
+# repo: r-lib/rlang
+# file: standalone-obj-type.R
+# last-updated: 2023-05-01
+# license: https://unlicense.org
+# imports: rlang (>= 1.1.0)
+# ---
+#
+# ## Changelog
+#
+# 2023-05-01:
+# - `obj_type_friendly()` now only displays the first class of S3 objects.
+#
+# 2023-03-30:
+# - `stop_input_type()` now handles `I()` input literally in `arg`.
+#
+# 2022-10-04:
+# - `obj_type_friendly(value = TRUE)` now shows numeric scalars
+#   literally.
+# - `stop_friendly_type()` now takes `show_value`, passed to
+#   `obj_type_friendly()` as the `value` argument.
+#
+# 2022-10-03:
+# - Added `allow_na` and `allow_null` arguments.
+# - `NULL` is now backticked.
+# - Better friendly type for infinities and `NaN`.
+#
+# 2022-09-16:
+# - Unprefixed usage of rlang functions with `rlang::` to
+#   avoid onLoad issues when called from rlang (#1482).
+#
+# 2022-08-11:
+# - Prefixed usage of rlang functions with `rlang::`.
+#
+# 2022-06-22:
+# - `friendly_type_of()` is now `obj_type_friendly()`.
+# - Added `obj_type_oo()`.
+#
+# 2021-12-20:
+# - Added support for scalar values and empty vectors.
+# - Added `stop_input_type()`
+#
+# 2021-06-30:
+# - Added support for missing arguments.
+#
+# 2021-04-19:
+# - Added support for matrices and arrays (#141).
+# - Added documentation.
+# - Added changelog.
+#
+# nocov start
+
+#' Return English-friendly type
+#' @param x Any R object.
+#' @param value Whether to describe the value of `x`. Special values
+#'   like `NA` or `""` are always described.
+#' @param length Whether to mention the length of vectors and lists.
+#' @return A string describing the type. Starts with an indefinite
+#'   article, e.g. "an integer vector".
+#' @noRd
+obj_type_friendly <- function(x, value = TRUE) {
+  if (is_missing(x)) {
+    return("absent")
+  }
+
+  if (is.object(x)) {
+    if (inherits(x, "quosure")) {
+      type <- "quosure"
+    } else {
+      type <- class(x)[[1L]]
+    }
+    return(sprintf("a <%s> object", type))
+  }
+
+  if (!is_vector(x)) {
+    return(.rlang_as_friendly_type(typeof(x)))
+  }
+
+  n_dim <- length(dim(x))
+
+  if (!n_dim) {
+    if (!is_list(x) && length(x) == 1) {
+      if (is_na(x)) {
+        return(switch(
+          typeof(x),
+          logical = "`NA`",
+          integer = "an integer `NA`",
+          double =
+            if (is.nan(x)) {
+              "`NaN`"
+            } else {
+              "a numeric `NA`"
+            },
+          complex = "a complex `NA`",
+          character = "a character `NA`",
+          .rlang_stop_unexpected_typeof(x)
+        ))
+      }
+
+      show_infinites <- function(x) {
+        if (x > 0) {
+          "`Inf`"
+        } else {
+          "`-Inf`"
+        }
+      }
+      str_encode <- function(x, width = 30, ...) {
+        if (nchar(x) > width) {
+          x <- substr(x, 1, width - 3)
+          x <- paste0(x, "...")
+        }
+        encodeString(x, ...)
+      }
+
+      if (value) {
+        if (is.numeric(x) && is.infinite(x)) {
+          return(show_infinites(x))
+        }
+
+        if (is.numeric(x) || is.complex(x)) {
+          number <- as.character(round(x, 2))
+          what <- if (is.complex(x)) "the complex number" else "the number"
+          return(paste(what, number))
+        }
+
+        return(switch(
+          typeof(x),
+          logical = if (x) "`TRUE`" else "`FALSE`",
+          character = {
+            what <- if (nzchar(x)) "the string" else "the empty string"
+            paste(what, str_encode(x, quote = "\""))
+          },
+          raw = paste("the raw value", as.character(x)),
+          .rlang_stop_unexpected_typeof(x)
+        ))
+      }
+
+      return(switch(
+        typeof(x),
+        logical = "a logical value",
+        integer = "an integer",
+        double = if (is.infinite(x)) show_infinites(x) else "a number",
+        complex = "a complex number",
+        character = if (nzchar(x)) "a string" else "\"\"",
+        raw = "a raw value",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+
+    if (length(x) == 0) {
+      return(switch(
+        typeof(x),
+        logical = "an empty logical vector",
+        integer = "an empty integer vector",
+        double = "an empty numeric vector",
+        complex = "an empty complex vector",
+        character = "an empty character vector",
+        raw = "an empty raw vector",
+        list = "an empty list",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+  }
+
+  vec_type_friendly(x)
+}
+
+vec_type_friendly <- function(x, length = FALSE) {
+  if (!is_vector(x)) {
+    abort("`x` must be a vector.")
+  }
+  type <- typeof(x)
+  n_dim <- length(dim(x))
+
+  add_length <- function(type) {
+    if (length && !n_dim) {
+      paste0(type, sprintf(" of length %s", length(x)))
+    } else {
+      type
+    }
+  }
+
+  if (type == "list") {
+    if (n_dim < 2) {
+      return(add_length("a list"))
+    } else if (is.data.frame(x)) {
+      return("a data frame")
+    } else if (n_dim == 2) {
+      return("a list matrix")
+    } else {
+      return("a list array")
+    }
+  }
+
+  type <- switch(
+    type,
+    logical = "a logical %s",
+    integer = "an integer %s",
+    numeric = ,
+    double = "a double %s",
+    complex = "a complex %s",
+    character = "a character %s",
+    raw = "a raw %s",
+    type = paste0("a ", type, " %s")
+  )
+
+  if (n_dim < 2) {
+    kind <- "vector"
+  } else if (n_dim == 2) {
+    kind <- "matrix"
+  } else {
+    kind <- "array"
+  }
+  out <- sprintf(type, kind)
+
+  if (n_dim >= 2) {
+    out
+  } else {
+    add_length(out)
+  }
+}
+
+.rlang_as_friendly_type <- function(type) {
+  switch(
+    type,
+
+    list = "a list",
+
+    NULL = "`NULL`",
+    environment = "an environment",
+    externalptr = "a pointer",
+    weakref = "a weak reference",
+    S4 = "an S4 object",
+
+    name = ,
+    symbol = "a symbol",
+    language = "a call",
+    pairlist = "a pairlist node",
+    expression = "an expression vector",
+
+    char = "an internal string",
+    promise = "an internal promise",
+    ... = "an internal dots object",
+    any = "an internal `any` object",
+    bytecode = "an internal bytecode object",
+
+    primitive = ,
+    builtin = ,
+    special = "a primitive function",
+    closure = "a function",
+
+    type
+  )
+}
+
+.rlang_stop_unexpected_typeof <- function(x, call = caller_env()) {
+  abort(
+    sprintf("Unexpected type <%s>.", typeof(x)),
+    call = call
+  )
+}
+
+#' Return OO type
+#' @param x Any R object.
+#' @return One of `"bare"` (for non-OO objects), `"S3"`, `"S4"`,
+#'   `"R6"`, or `"R7"`.
+#' @noRd
+obj_type_oo <- function(x) {
+  if (!is.object(x)) {
+    return("bare")
+  }
+
+  class <- inherits(x, c("R6", "R7_object"), which = TRUE)
+
+  if (class[[1]]) {
+    "R6"
+  } else if (class[[2]]) {
+    "R7"
+  } else if (isS4(x)) {
+    "S4"
+  } else {
+    "S3"
+  }
+}
+
+#' @param x The object type which does not conform to `what`. Its
+#'   `obj_type_friendly()` is taken and mentioned in the error message.
+#' @param what The friendly expected type as a string. Can be a
+#'   character vector of expected types, in which case the error
+#'   message mentions all of them in an "or" enumeration.
+#' @param show_value Passed to `value` argument of `obj_type_friendly()`.
+#' @param ... Arguments passed to [abort()].
+#' @inheritParams args_error_context
+#' @noRd
+stop_input_type <- function(x,
+                            what,
+                            ...,
+                            allow_na = FALSE,
+                            allow_null = FALSE,
+                            show_value = TRUE,
+                            arg = caller_arg(x),
+                            call = caller_env()) {
+  # From standalone-cli.R
+  cli <- env_get_list(
+    nms = c("format_arg", "format_code"),
+    last = topenv(),
+    default = function(x) sprintf("`%s`", x),
+    inherit = TRUE
+  )
+
+  if (allow_na) {
+    what <- c(what, cli$format_code("NA"))
+  }
+  if (allow_null) {
+    what <- c(what, cli$format_code("NULL"))
+  }
+  if (length(what)) {
+    what <- oxford_comma(what)
+  }
+  if (inherits(arg, "AsIs")) {
+    format_arg <- identity
+  } else {
+    format_arg <- cli$format_arg
+  }
+
+  message <- sprintf(
+    "%s must be %s, not %s.",
+    format_arg(arg),
+    what,
+    obj_type_friendly(x, value = show_value)
+  )
+
+  abort(message, ..., call = call, arg = arg)
+}
+
+oxford_comma <- function(chr, sep = ", ", final = "or") {
+  n <- length(chr)
+
+  if (n < 2) {
+    return(chr)
+  }
+
+  head <- chr[seq_len(n - 1)]
+  last <- chr[n]
+
+  head <- paste(head, collapse = sep)
+
+  # Write a or b. But a, b, or c.
+  if (n > 2) {
+    paste0(head, sep, final, " ", last)
+  } else {
+    paste0(head, " ", final, " ", last)
+  }
+}
+
+# nocov end

--- a/R/import-standalone-types-check.R
+++ b/R/import-standalone-types-check.R
@@ -1,0 +1,538 @@
+# Standalone file: do not edit by hand
+# Source: <https://github.com/r-lib/rlang/blob/main/R/standalone-types-check.R>
+# ----------------------------------------------------------------------
+#
+# ---
+# repo: r-lib/rlang
+# file: standalone-types-check.R
+# last-updated: 2023-03-13
+# license: https://unlicense.org
+# dependencies: standalone-obj-type.R
+# imports: rlang (>= 1.1.0)
+# ---
+#
+# ## Changelog
+#
+# 2023-03-13:
+# - Improved error messages of number checkers (@teunbrand)
+# - Added `allow_infinite` argument to `check_number_whole()` (@mgirlich).
+# - Added `check_data_frame()` (@mgirlich).
+#
+# 2023-03-07:
+# - Added dependency on rlang (>= 1.1.0).
+#
+# 2023-02-15:
+# - Added `check_logical()`.
+#
+# - `check_bool()`, `check_number_whole()`, and
+#   `check_number_decimal()` are now implemented in C.
+#
+# - For efficiency, `check_number_whole()` and
+#   `check_number_decimal()` now take a `NULL` default for `min` and
+#   `max`. This makes it possible to bypass unnecessary type-checking
+#   and comparisons in the default case of no bounds checks.
+#
+# 2022-10-07:
+# - `check_number_whole()` and `_decimal()` no longer treat
+#   non-numeric types such as factors or dates as numbers.  Numeric
+#   types are detected with `is.numeric()`.
+#
+# 2022-10-04:
+# - Added `check_name()` that forbids the empty string.
+#   `check_string()` allows the empty string by default.
+#
+# 2022-09-28:
+# - Removed `what` arguments.
+# - Added `allow_na` and `allow_null` arguments.
+# - Added `allow_decimal` and `allow_infinite` arguments.
+# - Improved errors with absent arguments.
+#
+#
+# 2022-09-16:
+# - Unprefixed usage of rlang functions with `rlang::` to
+#   avoid onLoad issues when called from rlang (#1482).
+#
+# 2022-08-11:
+# - Added changelog.
+#
+# nocov start
+
+# Scalars -----------------------------------------------------------------
+
+.standalone_types_check_dot_call <- .Call
+
+check_bool <- function(x,
+                       ...,
+                       allow_na = FALSE,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x) && .standalone_types_check_dot_call(ffi_standalone_is_bool_1.0.7, x, allow_na, allow_null)) {
+    return(invisible(NULL))
+  }
+
+  stop_input_type(
+    x,
+    c("`TRUE`", "`FALSE`"),
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_string <- function(x,
+                         ...,
+                         allow_empty = TRUE,
+                         allow_na = FALSE,
+                         allow_null = FALSE,
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!missing(x)) {
+    is_string <- .rlang_check_is_string(
+      x,
+      allow_empty = allow_empty,
+      allow_na = allow_na,
+      allow_null = allow_null
+    )
+    if (is_string) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a single string",
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+.rlang_check_is_string <- function(x,
+                                   allow_empty,
+                                   allow_na,
+                                   allow_null) {
+  if (is_string(x)) {
+    if (allow_empty || !is_string(x, "")) {
+      return(TRUE)
+    }
+  }
+
+  if (allow_null && is_null(x)) {
+    return(TRUE)
+  }
+
+  if (allow_na && (identical(x, NA) || identical(x, na_chr))) {
+    return(TRUE)
+  }
+
+  FALSE
+}
+
+check_name <- function(x,
+                       ...,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x)) {
+    is_string <- .rlang_check_is_string(
+      x,
+      allow_empty = FALSE,
+      allow_na = FALSE,
+      allow_null = allow_null
+    )
+    if (is_string) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a valid name",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+IS_NUMBER_true <- 0
+IS_NUMBER_false <- 1
+IS_NUMBER_oob <- 2
+
+check_number_decimal <- function(x,
+                                 ...,
+                                 min = NULL,
+                                 max = NULL,
+                                 allow_infinite = TRUE,
+                                 allow_na = FALSE,
+                                 allow_null = FALSE,
+                                 arg = caller_arg(x),
+                                 call = caller_env()) {
+  if (missing(x)) {
+    exit_code <- IS_NUMBER_false
+  } else if (0 == (exit_code <- .standalone_types_check_dot_call(
+    ffi_standalone_check_number_1.0.7,
+    x,
+    allow_decimal = TRUE,
+    min,
+    max,
+    allow_infinite,
+    allow_na,
+    allow_null
+  ))) {
+    return(invisible(NULL))
+  }
+
+  .stop_not_number(
+    x,
+    ...,
+    exit_code = exit_code,
+    allow_decimal = TRUE,
+    min = min,
+    max = max,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_number_whole <- function(x,
+                               ...,
+                               min = NULL,
+                               max = NULL,
+                               allow_infinite = FALSE,
+                               allow_na = FALSE,
+                               allow_null = FALSE,
+                               arg = caller_arg(x),
+                               call = caller_env()) {
+  if (missing(x)) {
+    exit_code <- IS_NUMBER_false
+  } else if (0 == (exit_code <- .standalone_types_check_dot_call(
+    ffi_standalone_check_number_1.0.7,
+    x,
+    allow_decimal = FALSE,
+    min,
+    max,
+    allow_infinite,
+    allow_na,
+    allow_null
+  ))) {
+    return(invisible(NULL))
+  }
+
+  .stop_not_number(
+    x,
+    ...,
+    exit_code = exit_code,
+    allow_decimal = FALSE,
+    min = min,
+    max = max,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+.stop_not_number <- function(x,
+                             ...,
+                             exit_code,
+                             allow_decimal,
+                             min,
+                             max,
+                             allow_na,
+                             allow_null,
+                             arg,
+                             call) {
+  if (allow_decimal) {
+    what <- "a number"
+  } else {
+    what <- "a whole number"
+  }
+
+  if (exit_code == IS_NUMBER_oob) {
+    min <- min %||% -Inf
+    max <- max %||% Inf
+
+    if (min > -Inf && max < Inf) {
+      what <- sprintf("%s between %s and %s", what, min, max)
+    } else if (x < min) {
+      what <- sprintf("%s larger than or equal to %s", what, min)
+    } else if (x > max) {
+      what <- sprintf("%s smaller than or equal to %s", what, max)
+    } else {
+      abort("Unexpected state in OOB check", .internal = TRUE)
+    }
+  }
+
+  stop_input_type(
+    x,
+    what,
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_symbol <- function(x,
+                         ...,
+                         allow_null = FALSE,
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!missing(x)) {
+    if (is_symbol(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a symbol",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_arg <- function(x,
+                      ...,
+                      allow_null = FALSE,
+                      arg = caller_arg(x),
+                      call = caller_env()) {
+  if (!missing(x)) {
+    if (is_symbol(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an argument name",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_call <- function(x,
+                       ...,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x)) {
+    if (is_call(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a defused call",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_environment <- function(x,
+                              ...,
+                              allow_null = FALSE,
+                              arg = caller_arg(x),
+                              call = caller_env()) {
+  if (!missing(x)) {
+    if (is_environment(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an environment",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_function <- function(x,
+                           ...,
+                           allow_null = FALSE,
+                           arg = caller_arg(x),
+                           call = caller_env()) {
+  if (!missing(x)) {
+    if (is_function(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a function",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_closure <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_closure(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an R function",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_formula <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_formula(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a formula",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+
+# Vectors -----------------------------------------------------------------
+
+check_character <- function(x,
+                            ...,
+                            allow_null = FALSE,
+                            arg = caller_arg(x),
+                            call = caller_env()) {
+  if (!missing(x)) {
+    if (is_character(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a character vector",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_logical <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_logical(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a logical vector",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_data_frame <- function(x,
+                             ...,
+                             allow_null = FALSE,
+                             arg = caller_arg(x),
+                             call = caller_env()) {
+  if (!missing(x)) {
+    if (is.data.frame(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a data frame",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+# nocov end

--- a/R/utils.R
+++ b/R/utils.R
@@ -168,14 +168,15 @@ random_name <- function(prefix = "") {
 
 # check helpers for common odbc arguments --------------------------------------
 check_row.names <- function(row.names, call = caller_env()) {
-  if (!inherits_any(row.names, c("logical", "character", "NULL")) ||
-      length(row.names) > 1) {
-    cli::cli_abort(
-      "{.arg row.names} must be {.code NULL}, {.code TRUE}, {.code FALSE}, \\
-       {.code NA}, or a single string, not {.obj_type_friendly {row.names}}.",
-      call = call
-    )
+  if (is.null(row.names) || is_scalar_logical(row.names) || is_string(row.names)) {
+    return()
   }
+
+  cli::cli_abort(
+    "{.arg row.names} must be {.code NULL}, {.code TRUE}, {.code FALSE}, \\
+     {.code NA}, or a single string, not {.obj_type_friendly {row.names}}.",
+    call = call
+  )
 }
 
 check_field.types <- function(field.types, call = caller_env()) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -165,3 +165,25 @@ random_name <- function(prefix = "") {
   name <- paste0(sample(vals, 10, replace = TRUE), collapse = "")
   paste0(prefix, "odbc_", name)
 }
+
+# check helpers for common odbc arguments --------------------------------------
+check_row.names <- function(row.names, call = caller_env()) {
+  if (!inherits_any(row.names, c("logical", "character", "NULL")) ||
+      length(row.names) > 1) {
+    cli::cli_abort(
+      "{.arg row.names} must be {.code NULL}, {.code TRUE}, {.code FALSE}, \\
+       {.code NA}, or a single string, not {.obj_type_friendly {row.names}}.",
+      call = call
+    )
+  }
+}
+
+check_field.types <- function(field.types, call = caller_env()) {
+  if (!(is_null(field.types) || (is_named(field.types)))) {
+    cli::cli_abort(
+      "{.arg field.types} must be {.code NULL} or a named vector of field \\
+       types, not {.obj_type_friendly {field.types}}.",
+      call = call
+    )
+  }
+}

--- a/tests/testthat/_snaps/driver-sql-server.md
+++ b/tests/testthat/_snaps/driver-sql-server.md
@@ -19,9 +19,9 @@
 
 # can create / write to temp table
 
-    Temporary flag is set to true, but table name doesn't use # prefix
+    `temporary` is `TRUE`, but table name doesn't use # prefix.
 
 ---
 
-    Temporary flag is set to true, but table name doesn't use # prefix
+    `temporary` is `TRUE`, but table name doesn't use # prefix.
 

--- a/tests/testthat/_snaps/driver-sqlite.md
+++ b/tests/testthat/_snaps/driver-sqlite.md
@@ -1,0 +1,25 @@
+# dbWriteTable() with `field.types` with `append = TRUE`
+
+    Code
+      dbWriteTable(con, "boopery", data.frame(bop = 1), field.types = c(bop = "numeric"),
+      append = TRUE)
+    Condition
+      Error in `dbWriteTable()`:
+      ! Cannot specify `field.types` with `append = TRUE`.
+
+# WriteTable() with `overwrite = TRUE` and `append = TRUE`
+
+    Code
+      dbWriteTable(con, "boopery", data.frame(bop = 1), overwrite = TRUE, append = TRUE)
+    Condition
+      Error in `dbWriteTable()`:
+      ! `overwrite` and `append` cannot both be "TRUE".
+
+# dbWriteTable(), existing table, `overwrite = FALSE`, `append = FALSE`
+
+    Code
+      dbWriteTable(con, "boopery", data.frame(bop = 1), overwrite = FALSE, append = FALSE)
+    Condition
+      Error in `dbWriteTable()`:
+      ! Table boopery exists in database, and both overwrite and append are `FALSE`.
+

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -11,3 +11,19 @@
       Error:
       ! Identifier must be length 1, 2, or 3.
 
+# check_row.names()
+
+    Code
+      dbWriteTable(con, "boopery", data.frame(bop = 1), row.names = c("no", "way"))
+    Condition
+      Error in `dbWriteTable()`:
+      ! `row.names` must be `NULL`, `TRUE`, `FALSE`, `NA`, or a single string, not a character vector.
+
+# check_field.types()
+
+    Code
+      dbWriteTable(con, "boopery", data.frame(bop = 1), field.types = "numeric")
+    Condition
+      Error in `dbWriteTable()`:
+      ! `field.types` must be `NULL` or a named vector of field types, not a string.
+

--- a/tests/testthat/test-driver-sqlite.R
+++ b/tests/testthat/test-driver-sqlite.R
@@ -147,3 +147,50 @@ test_that("odbcPreviewObject works", {
   })
   expect_equal(nrow(res), 3)
 })
+
+test_that("dbWriteTable() with `field.types` with `append = TRUE`", {
+  con <- test_con("SQLITE")
+
+  expect_snapshot(
+    error = TRUE,
+    dbWriteTable(
+      con,
+      "boopery",
+      data.frame(bop = 1),
+      field.types = c(bop = "numeric"),
+      append = TRUE
+    )
+  )
+})
+
+test_that("WriteTable() with `overwrite = TRUE` and `append = TRUE`", {
+  con <- test_con("SQLITE")
+
+  expect_snapshot(
+    error = TRUE,
+    dbWriteTable(
+      con,
+      "boopery",
+      data.frame(bop = 1),
+      overwrite = TRUE,
+      append = TRUE
+    )
+  )
+})
+
+test_that("dbWriteTable(), existing table, `overwrite = FALSE`, `append = FALSE`", {
+  con <- test_con("SQLITE")
+
+  local_table(con, "boopery", data.frame(bop = 1))
+
+  expect_snapshot(
+    error = TRUE,
+    dbWriteTable(
+      con,
+      "boopery",
+      data.frame(bop = 1),
+      overwrite = FALSE,
+      append = FALSE
+    )
+  )
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -54,3 +54,21 @@ test_that("getSelector", {
   expect_equal(getSelector("mykey", "%", exact = TRUE), " AND mykey LIKE '%'")
   expect_equal(getSelector("mykey", "%", exact = FALSE), " AND mykey LIKE '%'")
 })
+
+test_that("check_row.names()", {
+  con <- test_con("SQLITE")
+
+  expect_snapshot(
+    error = TRUE,
+    dbWriteTable(con, "boopery", data.frame(bop = 1), row.names = c("no", "way"))
+  )
+})
+
+test_that("check_field.types()", {
+  con <- test_con("SQLITE")
+
+  expect_snapshot(
+    error = TRUE,
+    dbWriteTable(con, "boopery", data.frame(bop = 1), field.types = "numeric")
+  )
+})


### PR DESCRIPTION
Related to #628 but does not close.

This PR introduces type checks for functions and their methods listed in "DBI Methods" in the function reference. Opening this PR just for that subset as this is already quite a large PR and will allow us to correct patterns early on.

To-do, either in a separate PR or here after one round of review (opinions?): functions in "ODBC configuration", "Database-specific helpers".

Transitioning away from base warnings and errors (see #627) where they're related to type checks but trying not to touch them generally.