### PR TITLE
check inputs for "ODBC configuration"

### DIFF
--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -93,6 +93,11 @@ odbcListObjects.OdbcConnection <- function(connection,
                                            name = NULL,
                                            type = NULL,
                                            ...) {
+  check_string(catalog, allow_null = TRUE)
+  check_string(schema, allow_null = TRUE)
+  check_string(name, allow_null = TRUE)
+  check_string(type, allow_null = TRUE)
+
   # if no catalog was supplied but this database has catalogs, return a list of
   # catalogs
   if (is.null(catalog)) {
@@ -221,6 +226,10 @@ odbcListColumns.OdbcConnection <- function(connection,
                                            catalog = NULL,
                                            schema = NULL,
                                            ...) {
+  check_string(table, allow_null = TRUE)
+  check_string(view, allow_null = TRUE)
+  check_string(catalog, allow_null = TRUE)
+  check_string(schema, allow_null = TRUE)
 
   # specify schema or catalog if given
   cols <- odbcConnectionColumns_(connection,
@@ -262,6 +271,12 @@ odbcPreviewObject.OdbcConnection <- function(connection,
                                              schema = NULL,
                                              catalog = NULL,
                                              ...) {
+  check_number_whole(rowLimit)
+  check_string(table, allow_null = TRUE)
+  check_string(view, allow_null = TRUE)
+  check_string(schema, allow_null = TRUE)
+  check_string(catalog, allow_null = TRUE)
+
   # extract object name from arguments
   name <- validateObjectName(table, view, ...)
 

--- a/R/odbc.R
+++ b/R/odbc.R
@@ -13,7 +13,7 @@
 #' odbcSetTransactionIsolationLevel(con, "SQL_TXN_READ_UNCOMMITTED")
 #' }
 odbcSetTransactionIsolationLevel <- function(conn, levels) {
-  arg_match(levels, values = names(odbc:::transactionLevels()), multiple = TRUE)
+  arg_match(levels, values = names(transactionLevels()), multiple = TRUE)
   # Convert to lowercase, spaces to underscores, remove sql_txn prefix
   levels <- tolower(levels)
   levels <- gsub(" ", "_", levels)

--- a/R/odbc.R
+++ b/R/odbc.R
@@ -13,6 +13,7 @@
 #' odbcSetTransactionIsolationLevel(con, "SQL_TXN_READ_UNCOMMITTED")
 #' }
 odbcSetTransactionIsolationLevel <- function(conn, levels) {
+  arg_match(levels, values = names(odbc:::transactionLevels()), multiple = TRUE)
   # Convert to lowercase, spaces to underscores, remove sql_txn prefix
   levels <- tolower(levels)
   levels <- gsub(" ", "_", levels)


### PR DESCRIPTION
Follow-up to #781, implementing checks for functions listed under "ODBC configuration" in the reference. ~~Related to #628 but does not close.~~ Closes #628--all functions listed under "Database-specific helpers" are checked sufficiently already.