### PR TITLE
correct type checking for `databricks(httpPath)`

### DIFF
--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -66,12 +66,11 @@ setMethod("dbConnect", "DatabricksOdbcDriver",
            pwd = NULL,
            ...) {
     # For backward compatibility with RStudio connection string
-    check_exclusive(httpPath, HTTPPath)
-    check_string(httpPath, allow_null = TRUE)
+    http_path <- check_exclusive(httpPath, HTTPPath)
+    check_string(get(http_path), allow_null = TRUE, arg = http_path)
     check_string(workspace, allow_null = TRUE)
     check_bool(useNativeQuery)
     check_string(driver, allow_null = TRUE)
-    check_string(HTTPPath, allow_null = TRUE)
     check_string(uid, allow_null = TRUE)
     check_string(pwd, allow_null = TRUE)
 

--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -65,14 +65,15 @@ setMethod("dbConnect", "DatabricksOdbcDriver",
            uid = NULL,
            pwd = NULL,
            ...) {
+    call <- caller_env()
     # For backward compatibility with RStudio connection string
-    http_path <- check_exclusive(httpPath, HTTPPath)
-    check_string(get(http_path), allow_null = TRUE, arg = http_path)
-    check_string(workspace, allow_null = TRUE)
-    check_bool(useNativeQuery)
-    check_string(driver, allow_null = TRUE)
-    check_string(uid, allow_null = TRUE)
-    check_string(pwd, allow_null = TRUE)
+    http_path <- check_exclusive(httpPath, HTTPPath, .call = call)
+    check_string(get(http_path), allow_null = TRUE, arg = http_path, call = call)
+    check_string(workspace, allow_null = TRUE, call = call)
+    check_bool(useNativeQuery, call = call)
+    check_string(driver, allow_null = TRUE, call = call)
+    check_string(uid, allow_null = TRUE, call = call)
+    check_string(pwd, allow_null = TRUE, call = call)
 
     args <- databricks_args(
       httpPath = if (missing(httpPath)) HTTPPath else httpPath,

--- a/tests/testthat/_snaps/driver-databricks.md
+++ b/tests/testthat/_snaps/driver-databricks.md
@@ -34,3 +34,27 @@
       ! Both `uid` and `pwd` must be specified for manual authentication.
       i Or leave both unset for automated authentication.
 
+# dbConnect method errors informatively re: httpPath (#787)
+
+    Code
+      dbConnect(databricks(), httpPath = "boop", HTTPPath = "bop")
+    Condition
+      Error in `dbConnect()`:
+      ! Exactly one of `httpPath` or `HTTPPath` must be supplied.
+
+---
+
+    Code
+      dbConnect(databricks(), HTTPPath = 1L)
+    Condition
+      Error in `dbConnect()`:
+      ! `HTTPPath` must be a single string or `NULL`, not the number 1.
+
+---
+
+    Code
+      dbConnect(databricks(), httpPath = 1L)
+    Condition
+      Error in `dbConnect()`:
+      ! `httpPath` must be a single string or `NULL`, not the number 1.
+

--- a/tests/testthat/test-driver-databricks.R
+++ b/tests/testthat/test-driver-databricks.R
@@ -89,13 +89,18 @@ test_that("supports OAuth M2M in env var", {
 })
 
 test_that("dbConnect method handles httpPath aliases (#787)", {
-  local_mocked_bindings(databricks_args = function(...) stop("made it"))
+  local_mocked_bindings(
+    databricks_args = function(...) stop("made it"),
+    configure_spark = function(...) TRUE
+  )
 
   expect_error(dbConnect(databricks(), HTTPPath = "boop"), "made it")
   expect_error(dbConnect(databricks(), httpPath = "boop"), "made it")
 })
 
 test_that("dbConnect method errors informatively re: httpPath (#787)", {
+  local_mocked_bindings(configure_spark = function(...) TRUE)
+
   expect_snapshot(
     error = TRUE,
     dbConnect(databricks(), httpPath = "boop", HTTPPath = "bop")

--- a/tests/testthat/test-driver-databricks.R
+++ b/tests/testthat/test-driver-databricks.R
@@ -89,7 +89,7 @@ test_that("supports OAuth M2M in env var", {
 })
 
 test_that("dbConnect method handles httpPath aliases (#787)", {
-  local_mocked_bindings(inject = function(...) stop("made it"))
+  local_mocked_bindings(databricks_args = function(...) stop("made it"))
 
   expect_error(dbConnect(databricks(), HTTPPath = "boop"), "made it")
   expect_error(dbConnect(databricks(), httpPath = "boop"), "made it")

--- a/tests/testthat/test-driver-databricks.R
+++ b/tests/testthat/test-driver-databricks.R
@@ -87,3 +87,20 @@ test_that("supports OAuth M2M in env var", {
   expect_equal(auth$auth_client_id, "abc")
   expect_equal(auth$auth_client_secret, "def")
 })
+
+test_that("dbConnect method handles httpPath aliases (#787)", {
+  local_mocked_bindings(inject = function(...) stop("made it"))
+
+  expect_error(dbConnect(databricks(), HTTPPath = "boop"), "made it")
+  expect_error(dbConnect(databricks(), httpPath = "boop"), "made it")
+})
+
+test_that("dbConnect method errors informatively re: httpPath (#787)", {
+  expect_snapshot(
+    error = TRUE,
+    dbConnect(databricks(), httpPath = "boop", HTTPPath = "bop")
+  )
+
+  expect_snapshot(error = TRUE, dbConnect(databricks(), HTTPPath = 1L))
+  expect_snapshot(error = TRUE, dbConnect(databricks(), httpPath = 1L))
+})


### PR DESCRIPTION
Closes #786. With this PR:

``` r
library(DBI)
library(odbc)

con <-
  dbConnect(
    databricks(),
    httpPath = "/sql/1.0/warehouses/<snip>"
  )

con <-
  dbConnect(
    databricks(),
    HTTPPath = "/sql/1.0/warehouses/<snip>"
  )

con <-
  dbConnect(
    databricks(),
    HTTPPath = 1L
  )
#> Error in `dbConnect()`:
#> ! `HTTPPath` must be a single string or `NULL`, not the number 1.

con <-
  dbConnect(
    databricks(),
    httpPath = "/sql/1.0/warehouses/<snip>",
    HTTPPath = "/sql/1.0/warehouses/<snip>"
  )
#> Error in `dbConnect()`:
#> ! Exactly one of `httpPath` or `HTTPPath` must be supplied.
```

<sup>Created on 2024-04-12 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>