### PR TITLE
rethrow database errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* Transitioned to the cli package for formatting most error messages 
+  (@simonpcouch, #781, #784, #785, #788).
+
 * `databricks()` will now automatically configure the needed driver and driver
   manager on macOS (#651).
 

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -25,6 +25,8 @@
 #include <map>
 #include <type_traits>
 
+#include <Rcpp.h>
+
 #ifndef __clang__
 #include <cstdint>
 #endif
@@ -494,13 +496,19 @@ const std::string database_error::state() const NANODBC_NOEXCEPT
     return sql_state;
 }
 
+void database_error::rethrow() {
+  Rcpp::Environment pkg = Rcpp::Environment::namespace_env("odbc");
+  Rcpp::Function rethrow_database_error = pkg["rethrow_database_error"];
+  rethrow_database_error(message);
+}
+
 } // namespace nanodbc
 
 // Throwing exceptions using NANODBC_THROW_DATABASE_ERROR enables file name
 // and line numbers to be inserted into the error message. Useful for debugging.
 #define NANODBC_THROW_DATABASE_ERROR(handle, handle_type)                                          \
-    throw nanodbc::database_error(                                                                 \
-        handle, handle_type, __FILE__ ":" NANODBC_STRINGIZE(__LINE__) ": ") /**/
+    nanodbc::database_error(                                                                 \
+        handle, handle_type, __FILE__ ":" NANODBC_STRINGIZE(__LINE__) ": ").rethrow() /**/
 
 // clang-format off
 // 8888888b.           888             d8b 888

--- a/src/nanodbc/nanodbc.h
+++ b/src/nanodbc/nanodbc.h
@@ -267,6 +267,7 @@ public:
     const char* what() const NANODBC_NOEXCEPT;
     long native() const NANODBC_NOEXCEPT;
     const std::string state() const NANODBC_NOEXCEPT;
+    void rethrow();
 
 private:
     long native_error;

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -19,6 +19,89 @@
       Error:
       ! Identifier must be length 1, 2, or 3.
 
+# errors are rethrown informatively (#643, #788)
+
+    Code
+      dbConnect(odbc(), dsn = "does_not_exist_db")
+    Condition
+      Error in `dbConnect()`:
+      i At 'nanodbc/nanodbc.cpp:1147', error 00000 from [unixODBC][Driver Manager].
+      x Data source name not found and no default driver specified
+
+---
+
+    Code
+      dbExecute(con, "SELECT * FROM boopbopbopbeep")
+    Condition
+      Error in `dbExecute()`:
+      i At 'nanodbc/nanodbc.cpp:1719', error 00000 from [SQLite].
+      x no such table: boopbopbopbeep (1)
+
+# rethrow_database_error() errors well when parse_database_error() fails
+
+    Code
+      rethrow_database_error("boop", call = NULL)
+    Condition
+      Error:
+      ! boop
+
+# parse_database_error() works with messages from the wild
+
+    Code
+      rethrow_database_error(
+        "nanodbc/nanodbc.cpp:1135: 00000\n       [unixODBC][Driver Manager]Data source name not found and no default driver specified",
+        call = NULL)
+    Condition
+      Error:
+      i At 'nanodbc/nanodbc.cpp:1135', error 00000 from [unixODBC][Driver Manager].
+      x  Data source name not found and no default driver specified
+
+---
+
+    Code
+      rethrow_database_error(
+        "nanodbc/nanodbc.cpp:1594: 07002\n       [Microsoft][ODBC Driver 17 for SQL Server]COUNT field incorrect or syntax error",
+        call = NULL)
+    Condition
+      Error:
+      i At 'nanodbc/nanodbc.cpp:1594', error 07002 from [Microsoft][ODBC Driver 17 for SQL Server].
+      x  COUNT field incorrect or syntax error
+
+---
+
+    Code
+      rethrow_database_error(
+        "nanodbc/nanodbc.cpp:1710: 07002\n       [ODBC Firebird Driver]COUNT field incorrect",
+        call = NULL)
+    Condition
+      Error:
+      i At 'nanodbc/nanodbc.cpp:1710', error 07002 from [ODBC Firebird Driver].
+      x  COUNT field incorrect
+
+---
+
+    Code
+      rethrow_database_error(
+        "nanodbc/nanodbc.cpp:1655: HYT00\n       [Microsoft][SQL Server Native Client 11.0]Query timeout expired",
+        call = NULL)
+    Condition
+      Error:
+      i At 'nanodbc/nanodbc.cpp:1655', error HYT00 from [Microsoft][SQL Server Native Client 11.0].
+      x  Query timeout expired
+
+---
+
+    Code
+      rethrow_database_error(
+        "nanodbc/nanodbc.cpp:1147: 00000\n       [Microsoft][ODBC Driver 18 for SQL Server]Login timeout expired\n       [Microsoft][ODBC Driver 18 for SQL Server]TCP Provider: Error code 0x2726\n       [Microsoft][ODBC Driver 18 for SQL Server]A network-related or instance-specific error has occurred while establishing a connection to 127.0.0.1. Server is not found or not accessible. Check if instance name is correct and if SQL Server is configured to allow remote connections. For more information see SQL Server Books Online. ",
+        call = NULL)
+    Condition
+      Error:
+      i At 'nanodbc/nanodbc.cpp:1147', error 00000 from [Microsoft][ODBC Driver 18 for SQL Server].
+      x  Login timeout expired
+      *  TCP Provider: Error code 0x2726
+      *  A network-related or instance-specific error has occurred while establishing a connection to 127.0.0.1. Server is not found or not accessible. Check if instance name is correct and if SQL Server is configured to allow remote connections. For more information see SQL Server Books Online.
+
 # check_row.names()
 
     Code

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -324,16 +324,3 @@ test_that("can create / write to temp table", {
   expect_snapshot_warning(sqlCreateTable(con, notTempTblName, values, temporary = TRUE))
   expect_no_warning(sqlCreateTable(con, notTempTblName, values, temporary = FALSE))
 })
-
-test_that("captures multiline errors message", {
-  tryCatch(
-    {
-      DBI::dbConnect(odbc::odbc(), dsn = "does_not_exist_db")
-    },
-    error = function(e) {
-      # Expect to see at least one newline character in message
-      # ( previously one long string, #643 )
-      expect_true(grepl("\n", e$message))
-    }
-  )
-})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -43,6 +43,73 @@ test_that("getSelector", {
   expect_equal(getSelector("mykey", "%", exact = FALSE), " AND mykey LIKE '%'")
 })
 
+test_that("errors are rethrown informatively (#643, #788)", {
+  skip_if_not(has_unixodbc())
+
+  expect_snapshot(error = TRUE, dbConnect(odbc(), dsn = "does_not_exist_db"))
+
+  con <- test_con("SQLITE")
+  expect_snapshot(error = TRUE, dbExecute(con, "SELECT * FROM boopbopbopbeep"))
+})
+
+test_that("rethrow_database_error() errors well when parse_database_error() fails", {
+  expect_snapshot(
+    error = TRUE,
+    rethrow_database_error("boop", call = NULL)
+  )
+})
+
+test_that("parse_database_error() works with messages from the wild", {
+  expect_snapshot(
+    error = TRUE,
+    rethrow_database_error(
+      "nanodbc/nanodbc.cpp:1135: 00000
+       [unixODBC][Driver Manager]Data source name not found and no default driver specified",
+      call = NULL
+    )
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    rethrow_database_error(
+      "nanodbc/nanodbc.cpp:1594: 07002
+       [Microsoft][ODBC Driver 17 for SQL Server]COUNT field incorrect or syntax error",
+      call = NULL
+    )
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    rethrow_database_error(
+      "nanodbc/nanodbc.cpp:1710: 07002
+       [ODBC Firebird Driver]COUNT field incorrect",
+      call = NULL
+    )
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    rethrow_database_error(
+      "nanodbc/nanodbc.cpp:1655: HYT00
+       [Microsoft][SQL Server Native Client 11.0]Query timeout expired",
+      call = NULL
+    )
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    rethrow_database_error(
+      "nanodbc/nanodbc.cpp:1147: 00000
+       [Microsoft][ODBC Driver 18 for SQL Server]Login timeout expired
+       [Microsoft][ODBC Driver 18 for SQL Server]TCP Provider: Error code 0x2726
+       [Microsoft][ODBC Driver 18 for SQL Server]A network-related or instance-specific error has occurred while establishing a connection to 127.0.0.1. Server is not found or not accessible. Check if instance name is correct and if SQL Server is configured to allow remote connections. For more information see SQL Server Books Online. ",
+      call = NULL
+    )
+  )
+
+
+})
+
 test_that("check_row.names()", {
   con <- test_con("SQLITE")
 


### PR DESCRIPTION
A follow-up to #643. At the time, parsing the message any further was agreed to be more painful than it was worth. Following up on PRs since then that refine the appearance of errors, this PR proposes rethrowing `nanodbc::database_error`s with cli formatting.

Before this PR:

``` r
library(DBI)
library(odbc)
con <- dbConnect(odbc(), dsn = "sillyhead")
#> Error: nanodbc/nanodbc.cpp:1138: 00000
#> [unixODBC][Driver Manager]Data source name not found and no default driver specified

con <- dbConnect(odbc(), dsn = "MicrosoftSQLServer", uid = "SA", pwd = Sys.getenv("sqlServerPass"))

dbExecute(con, "SELECT * FROM boopbopbopbeep")
#> Error in eval(expr, envir, enclos): nanodbc/nanodbc.cpp:1710: 00000
#> [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Invalid object name 'boopbopbopbeep'.
```

With this PR:

``` r
library(DBI)
library(odbc)
con <- dbConnect(odbc(), dsn = "sillyhead")
#> Error in `dbConnect()`:
#> ℹ At 'nanodbc/nanodbc.cpp:1147', error 00000 from [unixODBC][Driver
#>   Manager].
#> ✖ Data source name not found and no default driver specified

con <- dbConnect(odbc(), dsn = "MicrosoftSQLServer", uid = "SA", pwd = Sys.getenv("sqlServerPass"))

dbExecute(con, "SELECT * FROM boopbopbopbeep")
#> Error in `dbExecute()`:
#> ℹ At 'nanodbc/nanodbc.cpp:1719', error 00000 from [Microsoft][ODBC Driver
#>   18 for SQL Server][SQL Server].
#> ✖ Invalid object name 'boopbopbopbeep'.
```

<sup>Created on 2024-04-16 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

In the RStudio terminal, this looks like:

![Screenshot 2024-04-16 at 3 08 30 PM](https://github.com/r-dbi/odbc/assets/35748691/b983b7f2-f5b5-4fa1-bbae-b8b4c147c279)

