### PR TITLE
correct subset in `set_odbcsysini()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -139,7 +139,7 @@ set_odbcsysini <- function() {
 
   tryCatch(
     {
-      path <- dirname(odbcListConfig()["drivers"])
+      path <- dirname(odbcListConfig()[["drivers"]])
       Sys.setenv(ODBCSYSINI = path)
     },
     error = function(err) NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -139,7 +139,7 @@ set_odbcsysini <- function() {
 
   tryCatch(
     {
-      path <- dirname(odbcListConfig()$drivers)
+      path <- dirname(odbcListConfig()["drivers"])
       Sys.setenv(ODBCSYSINI = path)
     },
     error = function(err) NULL

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -43,6 +43,12 @@ test_that("getSelector", {
   expect_equal(getSelector("mykey", "%", exact = FALSE), " AND mykey LIKE '%'")
 })
 
+test_that("set_odbcsysini() works (#791)", {
+  skip_if(is_windows())
+
+  expect_false(identical(Sys.getenv("ODBCSYSINI"), ""))
+})
+
 test_that("check_row.names()", {
   con <- test_con("SQLITE")
 


### PR DESCRIPTION
Closes #791, a follow-up to #733.

```r
odbcListConfig()["drivers"]
#>                          drivers 
#> "/opt/homebrew/etc/odbcinst.ini" 
```