### PR TITLE
install unixODBC on `macOS-latest` runner

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,6 +55,11 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Install unixODBC
+        if: matrix.os == 'macOS-latest'
+        # unixODBC is not pre-installed on macos-14-arm64 runner (#794)
+        run: brew install unixodbc
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,7 +56,7 @@ jobs:
           needs: check
 
       - name: Install unixODBC
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macos-latest'
         # unixODBC is not pre-installed on macos-14-arm64 runner (#794)
         run: brew install unixodbc
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,7 +56,7 @@ jobs:
           needs: check
 
       - name: Install unixODBC
-        if: matrix.os == 'macos-latest'
+        if: matrix.config.os == 'macOS-latest'
         # unixODBC is not pre-installed on macos-14-arm64 runner (#794)
         run: brew install unixodbc
 


### PR DESCRIPTION
Closes #794. The [new runner image for macOS-latest](https://github.com/r-dbi/odbc/actions/runs/8787087319/job/24204887794#step:1:8) is [macos-14-arm64](https://github.com/actions/runner-images/blob/e63a194563cb0bb3bc1493144fe0ef6804249b43/images/macos/macos-14-arm64-Readme.md), which has brew available but not unixODBC. A few days ago, [it was macos-12](https://github.com/r-dbi/odbc/actions/runs/8786595710/job/24109812565#step:1:8).