### PR TITLE
Feature/interruptible execution clean2

### DIFF
--- a/.github/odbc/install-mariadb-driver.sh
+++ b/.github/odbc/install-mariadb-driver.sh
@@ -1,0 +1,9 @@
+sudo apt-get install -y cmake
+cd /tmp && git clone https://github.com/MariaDB/mariadb-connector-odbc.git connector
+cd connector && git checkout 3.1.17
+mkdir build && cd build
+cmake ../ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONC_WITH_UNIT_TESTS=Off -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_SSL=OPENSSL
+cmake --build . --config RelWithDebInfo
+sudo make install
+sudo ln -s /usr/local/lib/mariadb/libmariadb.so.3 /usr/local/lib/
+sudo ldconfig

--- a/.github/odbc/install-mariadb-driver.sh
+++ b/.github/odbc/install-mariadb-driver.sh
@@ -1,3 +1,5 @@
+# See #796 for some reasoning behind not using the canned mariadb-odbc-driver (v3.1.15), at time of writing
+# and needing to install v3.1.17 from source
 sudo apt-get install -y cmake
 cd /tmp && git clone https://github.com/MariaDB/mariadb-connector-odbc.git connector
 cd connector && git checkout 3.1.17

--- a/.github/odbc/odbcinst.ini
+++ b/.github/odbc/odbcinst.ini
@@ -7,7 +7,7 @@ FileUsage=1
 Threading=2
 
 [MySQL Driver]
-Driver=/usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so
+Driver=/usr/local/lib/mariadb/libmaodbc.so
 UsageCount = 1
 Threading=2
 

--- a/.github/workflows/db-windows.yml
+++ b/.github/workflows/db-windows.yml
@@ -93,5 +93,5 @@ jobs:
 
       - name: Test
         run: |
-          testthat::test_local(reporter = testthat::ProgressReporter$new(max_failures = Inf, update_interval = Inf))
+          options("odbc.interruptible"=TRUE);testthat::test_local(reporter = testthat::ProgressReporter$new(max_failures = Inf, update_interval = Inf))
         shell: Rscript {0}

--- a/.github/workflows/db.yaml
+++ b/.github/workflows/db.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           sudo systemctl start mysql.service
           mysql -uroot -h127.0.0.1 -proot -e 'CREATE DATABASE `test`;'
-          sudo apt-get install -y odbc-mariadb
+          .github/odbc/install-mariadb-driver.sh
           echo "ODBC_CS_MYSQL=dsn=MySQL" >> $GITHUB_ENV
 
       - name: Install SQLite Driver

--- a/.github/workflows/db.yaml
+++ b/.github/workflows/db.yaml
@@ -118,5 +118,5 @@ jobs:
 
       - name: Test
         run: |
-          testthat::test_local(reporter = testthat::ProgressReporter$new(max_failures = Inf, update_interval = Inf))
+          options("odbc.interruptible"=TRUE);testthat::test_local(reporter = testthat::ProgressReporter$new(max_failures = Inf, update_interval = Inf))
         shell: Rscript {0}

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # odbc (development version)
 
+* Long running queries can now be interrupted using Ctrl-C.  This
+  feature is enabled by default and can be controlled by the `interruptible`
+  argument to `dbConnect`, or by the global option `odbc.interruptible`.
+  Should be considered experimental - if you experience problems please
+  file an issue on the package github repository (#796)
+
 * Raises "Cancelling previous query" warnings from R rather than from Rcpp when 
   a connection has a current result to avoid possible incorrect resource 
   unwinds with `options(warn = 2)` (#797).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 # odbc (development version)
 
 * Long running queries can now be interrupted using Ctrl-C.  This
-  feature is enabled by default and can be controlled by the `interruptible`
-  argument to `dbConnect`, or by the global option `odbc.interruptible`.
-  Should be considered experimental - if you experience problems please
-  file an issue on the package github repository (#796)
+  feature is enabled by default in interactive sessions.  It can be
+  controlled by the `interruptible` argument to `dbConnect`, or by the
+  global option `odbc.interruptible`.  Should be considered experimental -
+  if you experience problems please file an issue on the package github
+  repository (#796).
 
 * Raises "Cancelling previous query" warnings from R rather than from Rcpp when 
   a connection has a current result to avoid possible incorrect resource 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,8 +9,8 @@ list_data_sources_ <- function() {
     .Call(`_odbc_list_data_sources_`)
 }
 
-odbc_connect <- function(connection_string, timezone = "", timezone_out = "", encoding = "", bigint = 0L, timeout = 0L, r_attributes_ = NULL) {
-    .Call(`_odbc_odbc_connect`, connection_string, timezone, timezone_out, encoding, bigint, timeout, r_attributes_)
+odbc_connect <- function(connection_string, timezone = "", timezone_out = "", encoding = "", bigint = 0L, timeout = 0L, r_attributes = NULL, interruptible_execution = TRUE) {
+    .Call(`_odbc_odbc_connect`, connection_string, timezone, timezone_out, encoding, bigint, timeout, r_attributes, interruptible_execution)
 }
 
 has_result <- function(p) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -105,10 +105,6 @@ result_bind <- function(r, params, batch_rows) {
     invisible(.Call(`_odbc_result_bind`, r, params, batch_rows))
 }
 
-result_execute <- function(r) {
-    invisible(.Call(`_odbc_result_execute`, r))
-}
-
 result_insert_dataframe <- function(r, df, batch_rows) {
     invisible(.Call(`_odbc_result_insert_dataframe`, r, df, batch_rows))
 }

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -63,8 +63,11 @@ setMethod("show", "OdbcDriver",
 #'   name for the OdbcConnection object returned from [dbConnect()]. However, if
 #'   the driver does not return a valid value, it can be set manually with this
 #'   parameter.
-#' @param attributes An S4 object of connection attributes that are passed
+#' @param attributes A list of connection attributes that are passed
 #'   prior to the connection being established. See \link{ConnectionAttributes}.
+#' @param interruptibleExecution Logical.  If true calls to SQLExecute and
+#'   SQLExecuteDirect can be interrupted when the user sends SIGINT ( ctrl-c ).
+#'   Otherwise they block.  Defaults to TRUE.
 #' @param ... Additional ODBC keywords. These will be joined with the other
 #'   arguments to form the final connection string.
 #'
@@ -167,6 +170,7 @@ setMethod("dbConnect", "OdbcDriver",
       pwd = NULL,
       dbms.name = NULL,
       attributes = NULL,
+      interruptibleExecution = TRUE,
       .connection_string = NULL) {
     check_string(dsn, allow_null = TRUE)
     check_string(timezone, allow_null = TRUE)
@@ -196,6 +200,7 @@ setMethod("dbConnect", "OdbcDriver",
       pwd = pwd,
       dbms.name = dbms.name,
       attributes = attributes,
+      interruptibleExecution = interruptibleExecution,
       .connection_string = .connection_string
     )
 

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -65,9 +65,9 @@ setMethod("show", "OdbcDriver",
 #'   parameter.
 #' @param attributes A list of connection attributes that are passed
 #'   prior to the connection being established. See \link{ConnectionAttributes}.
-#' @param interruptibleExecution Logical.  If true calls to SQLExecute and
+#' @param interruptibleExecution Logical.  If `TRUE` calls to SQLExecute and
 #'   SQLExecuteDirect can be interrupted when the user sends SIGINT ( ctrl-c ).
-#'   Otherwise they block.  Defaults to TRUE.
+#'   Otherwise, they block.  Defaults to `TRUE`.
 #' @param ... Additional ODBC keywords. These will be joined with the other
 #'   arguments to form the final connection string.
 #'
@@ -184,6 +184,7 @@ setMethod("dbConnect", "OdbcDriver",
     check_string(uid, allow_null = TRUE)
     check_string(pwd, allow_null = TRUE)
     check_string(dbms.name, allow_null = TRUE)
+    check_bool(interruptibleExecution)
 
     con <- OdbcConnection(
       dsn = dsn,

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -65,9 +65,11 @@ setMethod("show", "OdbcDriver",
 #'   parameter.
 #' @param attributes A list of connection attributes that are passed
 #'   prior to the connection being established. See \link{ConnectionAttributes}.
-#' @param interruptibleExecution Logical.  If `TRUE` calls to SQLExecute and
-#'   SQLExecuteDirect can be interrupted when the user sends SIGINT ( ctrl-c ).
-#'   Otherwise, they block.  Defaults to `TRUE`.
+#' @param interruptible Logical.  If `TRUE` calls to `SQLExecute` and
+#'   `SQLExecuteDirect` can be interrupted when the user sends SIGINT ( ctrl-c ).
+#'   Otherwise, they block.  Defaults to `TRUE`.  It can be set either by
+#'   manipulating this argument, or setting the global option `odbc.interruptible`
+#'   to `FALSE`.
 #' @param ... Additional ODBC keywords. These will be joined with the other
 #'   arguments to form the final connection string.
 #'
@@ -170,7 +172,7 @@ setMethod("dbConnect", "OdbcDriver",
       pwd = NULL,
       dbms.name = NULL,
       attributes = NULL,
-      interruptibleExecution = TRUE,
+      interruptible = getOption("odbc.interruptible", TRUE),
       .connection_string = NULL) {
     check_string(dsn, allow_null = TRUE)
     check_string(timezone, allow_null = TRUE)
@@ -184,7 +186,7 @@ setMethod("dbConnect", "OdbcDriver",
     check_string(uid, allow_null = TRUE)
     check_string(pwd, allow_null = TRUE)
     check_string(dbms.name, allow_null = TRUE)
-    check_bool(interruptibleExecution)
+    check_bool(interruptible)
 
     con <- OdbcConnection(
       dsn = dsn,
@@ -201,7 +203,7 @@ setMethod("dbConnect", "OdbcDriver",
       pwd = pwd,
       dbms.name = dbms.name,
       attributes = attributes,
-      interruptibleExecution = interruptibleExecution,
+      interruptible = interruptible,
       .connection_string = .connection_string
     )
 

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -67,9 +67,9 @@ setMethod("show", "OdbcDriver",
 #'   prior to the connection being established. See \link{ConnectionAttributes}.
 #' @param interruptible Logical.  If `TRUE` calls to `SQLExecute` and
 #'   `SQLExecuteDirect` can be interrupted when the user sends SIGINT ( ctrl-c ).
-#'   Otherwise, they block.  Defaults to `TRUE`.  It can be set either by
-#'   manipulating this argument, or setting the global option `odbc.interruptible`
-#'   to `FALSE`.
+#'   Otherwise, they block.  Defaults to `TRUE` in interactive sessions, and
+#'   `FALSE` otherwise.  It can be set explicitly either by manipulating this
+#'   argument, or by setting the global option `odbc.interruptible`.
 #' @param ... Additional ODBC keywords. These will be joined with the other
 #'   arguments to form the final connection string.
 #'
@@ -172,7 +172,7 @@ setMethod("dbConnect", "OdbcDriver",
       pwd = NULL,
       dbms.name = NULL,
       attributes = NULL,
-      interruptible = getOption("odbc.interruptible", TRUE),
+      interruptible = getOption("odbc.interruptible", interactive()),
       .connection_string = NULL) {
     check_string(dsn, allow_null = TRUE)
     check_string(timezone, allow_null = TRUE)

--- a/R/odbc-connection.R
+++ b/R/odbc-connection.R
@@ -14,7 +14,7 @@ OdbcConnection <- function(
     timeout = Inf,
     dbms.name = NULL,
     attributes = NULL,
-    interruptibleExecution = TRUE,
+    interruptible = getOption("odbc.interruptible", TRUE),
     .connection_string = NULL,
     call = caller_env(2)
 ) {
@@ -39,7 +39,7 @@ OdbcConnection <- function(
       bigint = bigint,
       timeout = timeout,
       r_attributes = attributes,
-      interruptible_execution = interruptibleExecution
+      interruptible_execution = interruptible
     ),
     error = function(cnd) {
       check_quoting(args)

--- a/R/odbc-connection.R
+++ b/R/odbc-connection.R
@@ -14,6 +14,7 @@ OdbcConnection <- function(
     timeout = Inf,
     dbms.name = NULL,
     attributes = NULL,
+    interruptibleExecution = TRUE,
     .connection_string = NULL,
     call = caller_env(2)
 ) {
@@ -37,7 +38,8 @@ OdbcConnection <- function(
       encoding = encoding,
       bigint = bigint,
       timeout = timeout,
-      r_attributes_ = attributes
+      r_attributes = attributes,
+      interruptible_execution = interruptibleExecution
     ),
     error = function(cnd) {
       check_quoting(args)

--- a/R/odbc-connection.R
+++ b/R/odbc-connection.R
@@ -14,7 +14,7 @@ OdbcConnection <- function(
     timeout = Inf,
     dbms.name = NULL,
     attributes = NULL,
-    interruptible = getOption("odbc.interruptible", TRUE),
+    interruptible = getOption("odbc.interruptible", interactive()),
     .connection_string = NULL,
     call = caller_env(2)
 ) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -154,6 +154,19 @@ random_name <- function(prefix = "") {
   paste0(prefix, "odbc_", name)
 }
 
+# formatted message display ---------------------------------------------------
+# This method is called from the C++ side.  We use `package::cli` to format
+# the message.  If type != "i", in addition the displaying the message we
+# also generate an [R] warning ( via cli::warn ).  See rethrow_database_error
+# for re-formatting (database) errors ( also called from C code-base).
+print_message <- function(msg, type = "i") {
+  if (type == "i") {
+    cli::cli_inform(c("i" = msg));
+  } else {
+    cli::cli_warn(c("!" = msg));
+  }
+}
+
 # error handling ---------------------------------------------------------------
 # `call` looks to the "user-called" function rather than the usual `caller_env(n)`.
 # this function is called from C++, and parent.frame() (and thus caller_env())

--- a/R/utils.R
+++ b/R/utils.R
@@ -154,19 +154,6 @@ random_name <- function(prefix = "") {
   paste0(prefix, "odbc_", name)
 }
 
-# formatted message display ---------------------------------------------------
-# This method is called from the C++ side.  We use `package::cli` to format
-# the message.  If type != "i", in addition the displaying the message we
-# also generate an [R] warning ( via cli::warn ).  See rethrow_database_error
-# for re-formatting (database) errors ( also called from C code-base).
-print_message <- function(msg, type = "i") {
-  if (type == "i") {
-    cli::cli_inform(c("i" = msg));
-  } else {
-    cli::cli_warn(c("!" = msg));
-  }
-}
-
 # error handling ---------------------------------------------------------------
 # `call` looks to the "user-called" function rather than the usual `caller_env(n)`.
 # this function is called from C++, and parent.frame() (and thus caller_env())

--- a/man/OdbcResult.Rd
+++ b/man/OdbcResult.Rd
@@ -54,7 +54,7 @@ with one column per query parameter.}
 
 \item{batch_rows}{The number of rows to retrieve. Defaults to \code{NA}, which
 is set dynamically to the minimum of 1024 and the size of the input.
-Depending on the database, driver, dataset and free memory setting this
+Depending on the database, driver, dataset and free memory, setting this
 to a lower value may improve performance.}
 }
 \description{

--- a/man/dbConnect-OdbcDriver-method.Rd
+++ b/man/dbConnect-OdbcDriver-method.Rd
@@ -24,6 +24,7 @@ odbc()
   pwd = NULL,
   dbms.name = NULL,
   attributes = NULL,
+  interruptibleExecution = TRUE,
   .connection_string = NULL
 )
 }
@@ -86,8 +87,12 @@ name for the OdbcConnection object returned from \code{\link[=dbConnect]{dbConne
 the driver does not return a valid value, it can be set manually with this
 parameter.}
 
-\item{attributes}{An S4 object of connection attributes that are passed
+\item{attributes}{A list of connection attributes that are passed
 prior to the connection being established. See \link{ConnectionAttributes}.}
+
+\item{interruptibleExecution}{Logical.  If true calls to SQLExecute and
+SQLExecuteDirect can be interrupted when the user sends SIGINT ( ctrl-c ).
+Otherwise they block.  Defaults to TRUE.}
 
 \item{.connection_string}{A complete connection string, useful if you are
 copy pasting it from another source. If this argument is used, any

--- a/man/dbConnect-OdbcDriver-method.Rd
+++ b/man/dbConnect-OdbcDriver-method.Rd
@@ -90,9 +90,9 @@ parameter.}
 \item{attributes}{A list of connection attributes that are passed
 prior to the connection being established. See \link{ConnectionAttributes}.}
 
-\item{interruptibleExecution}{Logical.  If true calls to SQLExecute and
+\item{interruptibleExecution}{Logical.  If \code{TRUE} calls to SQLExecute and
 SQLExecuteDirect can be interrupted when the user sends SIGINT ( ctrl-c ).
-Otherwise they block.  Defaults to TRUE.}
+Otherwise, they block.  Defaults to \code{TRUE}.}
 
 \item{.connection_string}{A complete connection string, useful if you are
 copy pasting it from another source. If this argument is used, any

--- a/man/dbConnect-OdbcDriver-method.Rd
+++ b/man/dbConnect-OdbcDriver-method.Rd
@@ -24,7 +24,7 @@ odbc()
   pwd = NULL,
   dbms.name = NULL,
   attributes = NULL,
-  interruptibleExecution = TRUE,
+  interruptible = getOption("odbc.interruptible", TRUE),
   .connection_string = NULL
 )
 }
@@ -90,9 +90,11 @@ parameter.}
 \item{attributes}{A list of connection attributes that are passed
 prior to the connection being established. See \link{ConnectionAttributes}.}
 
-\item{interruptibleExecution}{Logical.  If \code{TRUE} calls to SQLExecute and
-SQLExecuteDirect can be interrupted when the user sends SIGINT ( ctrl-c ).
-Otherwise, they block.  Defaults to \code{TRUE}.}
+\item{interruptible}{Logical.  If \code{TRUE} calls to \code{SQLExecute} and
+\code{SQLExecuteDirect} can be interrupted when the user sends SIGINT ( ctrl-c ).
+Otherwise, they block.  Defaults to \code{TRUE}.  It can be set either by
+manipulating this argument, or setting the global option \code{odbc.interruptible}
+to \code{FALSE}.}
 
 \item{.connection_string}{A complete connection string, useful if you are
 copy pasting it from another source. If this argument is used, any

--- a/man/dbConnect-OdbcDriver-method.Rd
+++ b/man/dbConnect-OdbcDriver-method.Rd
@@ -24,7 +24,7 @@ odbc()
   pwd = NULL,
   dbms.name = NULL,
   attributes = NULL,
-  interruptible = getOption("odbc.interruptible", TRUE),
+  interruptible = getOption("odbc.interruptible", interactive()),
   .connection_string = NULL
 )
 }
@@ -92,9 +92,9 @@ prior to the connection being established. See \link{ConnectionAttributes}.}
 
 \item{interruptible}{Logical.  If \code{TRUE} calls to \code{SQLExecute} and
 \code{SQLExecuteDirect} can be interrupted when the user sends SIGINT ( ctrl-c ).
-Otherwise, they block.  Defaults to \code{TRUE}.  It can be set either by
-manipulating this argument, or setting the global option \code{odbc.interruptible}
-to \code{FALSE}.}
+Otherwise, they block.  Defaults to \code{TRUE} in interactive sessions, and
+\code{FALSE} otherwise.  It can be set explicitly either by manipulating this
+argument, or by setting the global option \code{odbc.interruptible}.}
 
 \item{.connection_string}{A complete connection string, useful if you are
 copy pasting it from another source. If this argument is used, any

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -306,16 +306,6 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
-// result_execute
-void result_execute(result_ptr const& r);
-RcppExport SEXP _odbc_result_execute(SEXP rSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< result_ptr const& >::type r(rSEXP);
-    result_execute(r);
-    return R_NilValue;
-END_RCPP
-}
 // result_insert_dataframe
 void result_insert_dataframe(result_ptr const& r, DataFrame const& df, size_t batch_rows);
 RcppExport SEXP _odbc_result_insert_dataframe(SEXP rSEXP, SEXP dfSEXP, SEXP batch_rowsSEXP) {
@@ -399,7 +389,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_odbc_result_fetch", (DL_FUNC) &_odbc_result_fetch, 2},
     {"_odbc_result_column_info", (DL_FUNC) &_odbc_result_column_info, 1},
     {"_odbc_result_bind", (DL_FUNC) &_odbc_result_bind, 3},
-    {"_odbc_result_execute", (DL_FUNC) &_odbc_result_execute, 1},
     {"_odbc_result_insert_dataframe", (DL_FUNC) &_odbc_result_insert_dataframe, 3},
     {"_odbc_result_describe_parameters", (DL_FUNC) &_odbc_result_describe_parameters, 2},
     {"_odbc_result_rows_affected", (DL_FUNC) &_odbc_result_rows_affected, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -32,8 +32,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // odbc_connect
-connection_ptr odbc_connect(std::string const& connection_string, std::string const& timezone, std::string const& timezone_out, std::string const& encoding, int bigint, long timeout, Rcpp::Nullable<Rcpp::List> const& r_attributes_);
-RcppExport SEXP _odbc_odbc_connect(SEXP connection_stringSEXP, SEXP timezoneSEXP, SEXP timezone_outSEXP, SEXP encodingSEXP, SEXP bigintSEXP, SEXP timeoutSEXP, SEXP r_attributes_SEXP) {
+connection_ptr odbc_connect(std::string const& connection_string, std::string const& timezone, std::string const& timezone_out, std::string const& encoding, int bigint, long timeout, Rcpp::Nullable<Rcpp::List> const& r_attributes, bool const& interruptible_execution);
+RcppExport SEXP _odbc_odbc_connect(SEXP connection_stringSEXP, SEXP timezoneSEXP, SEXP timezone_outSEXP, SEXP encodingSEXP, SEXP bigintSEXP, SEXP timeoutSEXP, SEXP r_attributesSEXP, SEXP interruptible_executionSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -43,8 +43,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::string const& >::type encoding(encodingSEXP);
     Rcpp::traits::input_parameter< int >::type bigint(bigintSEXP);
     Rcpp::traits::input_parameter< long >::type timeout(timeoutSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::List> const& >::type r_attributes_(r_attributes_SEXP);
-    rcpp_result_gen = Rcpp::wrap(odbc_connect(connection_string, timezone, timezone_out, encoding, bigint, timeout, r_attributes_));
+    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::List> const& >::type r_attributes(r_attributesSEXP);
+    Rcpp::traits::input_parameter< bool const& >::type interruptible_execution(interruptible_executionSEXP);
+    rcpp_result_gen = Rcpp::wrap(odbc_connect(connection_string, timezone, timezone_out, encoding, bigint, timeout, r_attributes, interruptible_execution));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -365,7 +366,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_odbc_list_drivers_", (DL_FUNC) &_odbc_list_drivers_, 0},
     {"_odbc_list_data_sources_", (DL_FUNC) &_odbc_list_data_sources_, 0},
-    {"_odbc_odbc_connect", (DL_FUNC) &_odbc_odbc_connect, 7},
+    {"_odbc_odbc_connect", (DL_FUNC) &_odbc_odbc_connect, 8},
     {"_odbc_has_result", (DL_FUNC) &_odbc_has_result, 1},
     {"_odbc_connection_info", (DL_FUNC) &_odbc_connection_info, 1},
     {"_odbc_connection_quote", (DL_FUNC) &_odbc_connection_quote, 1},

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -53,7 +53,8 @@ connection_ptr odbc_connect(
     std::string const& encoding = "",
     int bigint = 0,
     long timeout = 0,
-    Rcpp::Nullable<Rcpp::List> const& r_attributes_ = R_NilValue) {
+    Rcpp::Nullable<Rcpp::List> const& r_attributes = R_NilValue,
+    bool const& interruptible_execution = true) {
   return connection_ptr(
       new std::shared_ptr<odbc_connection>(new odbc_connection(
           connection_string,
@@ -62,7 +63,8 @@ connection_ptr odbc_connect(
           encoding,
           static_cast<bigint_map_t>(bigint),
           timeout,
-          r_attributes_)));
+          r_attributes,
+          interruptible_execution)));
 }
 
 std::string get_info_or_empty(connection_ptr const& p, short type) {

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -496,19 +496,13 @@ const std::string database_error::state() const NANODBC_NOEXCEPT
     return sql_state;
 }
 
-void database_error::rethrow() {
-  Rcpp::Environment pkg = Rcpp::Environment::namespace_env("odbc");
-  Rcpp::Function rethrow_database_error = pkg["rethrow_database_error"];
-  rethrow_database_error(message);
-}
-
 } // namespace nanodbc
 
 // Throwing exceptions using NANODBC_THROW_DATABASE_ERROR enables file name
 // and line numbers to be inserted into the error message. Useful for debugging.
 #define NANODBC_THROW_DATABASE_ERROR(handle, handle_type)                                          \
-    nanodbc::database_error(                                                                 \
-        handle, handle_type, __FILE__ ":" NANODBC_STRINGIZE(__LINE__) ": ").rethrow() /**/
+    throw nanodbc::database_error(                                                                 \
+        handle, handle_type, __FILE__ ":" NANODBC_STRINGIZE(__LINE__) ": ") /**/
 
 // clang-format off
 // 8888888b.           888             d8b 888

--- a/src/nanodbc/nanodbc.h
+++ b/src/nanodbc/nanodbc.h
@@ -267,7 +267,6 @@ public:
     const char* what() const NANODBC_NOEXCEPT;
     long native() const NANODBC_NOEXCEPT;
     const std::string state() const NANODBC_NOEXCEPT;
-    void rethrow();
 
 private:
     long native_error;

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -33,11 +33,13 @@ odbc_connection::odbc_connection(
     std::string encoding,
     bigint_map_t bigint_mapping,
     long timeout,
-    Rcpp::Nullable<Rcpp::List> const& r_attributes_)
+    Rcpp::Nullable<Rcpp::List> const& r_attributes,
+    bool const& interruptible_execution)
     : current_result_(nullptr),
       timezone_out_str_(timezone_out),
       encoding_(encoding),
-      bigint_mapping_(bigint_mapping) {
+      bigint_mapping_(bigint_mapping),
+      interruptible_execution_(interruptible_execution) {
 
   if (!cctz::load_time_zone(timezone, &timezone_)) {
     Rcpp::stop("Error loading time zone (%s)", timezone);
@@ -53,7 +55,7 @@ odbc_connection::odbc_connection(
     std::list< nanodbc::connection::attribute > attributes;
     std::list< std::shared_ptr< void > > buffer_context;
     utils::prepare_connection_attributes(
-        timeout, r_attributes_, attributes, buffer_context );
+        timeout, r_attributes, attributes, buffer_context );
     c_ = std::make_shared<nanodbc::connection>(connection_string, attributes);
   } catch (const nanodbc::database_error& e) {
     throw Rcpp::exception(e.what(), FALSE);

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -59,7 +59,7 @@ odbc_connection::odbc_connection(
     c_ = std::make_shared<nanodbc::connection>(connection_string, attributes);
   } catch (const nanodbc::database_error& e) {
     Iconv encoder(this->encoding(), "UTF-8");
-    odbc_error(e, "", encoder).pretty_print();
+    utils::raise_error(odbc_error(e, "", encoder));
   }
 }
 

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -58,7 +58,8 @@ odbc_connection::odbc_connection(
         timeout, r_attributes, attributes, buffer_context );
     c_ = std::make_shared<nanodbc::connection>(connection_string, attributes);
   } catch (const nanodbc::database_error& e) {
-    throw Rcpp::exception(e.what(), FALSE);
+    Iconv encoder(this->encoding(), "UTF-8");
+    odbc_error(e, "", encoder).pretty_print();
   }
 }
 

--- a/src/odbc_connection.h
+++ b/src/odbc_connection.h
@@ -26,7 +26,8 @@ public:
       std::string encoding = "",
       bigint_map_t bigint_mapping = i64_to_integer64,
       long timeout = 0,
-      Rcpp::Nullable<Rcpp::List> const& r_attributes_ = R_NilValue);
+      Rcpp::Nullable<Rcpp::List> const& r_attributes = R_NilValue,
+      bool const& interruptible_execution = true);
 
   std::shared_ptr<nanodbc::connection> connection() const;
 
@@ -57,5 +58,6 @@ private:
   std::string timezone_out_str_;
   std::string encoding_;
   bigint_map_t bigint_mapping_;
+  bool interruptible_execution_;
 };
 } // namespace odbc

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -35,12 +35,6 @@ public:
   }
   const char* what() const NANODBC_NOEXCEPT { return message.c_str(); }
 
-  void pretty_print() const {
-    Rcpp::Environment pkg = Rcpp::Environment::namespace_env("odbc");
-    Rcpp::Function rethrow_database_error = pkg["rethrow_database_error"];
-    rethrow_database_error(message);
-  }
-
 private:
   // #432: must be native encoded, as R expects native encoded chars for error msg
   std::string message;

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -25,7 +25,7 @@ public:
       Iconv& output_encoder)
       : Rcpp::exception("", false) {
     std::string m = std::string(e.what());
-    if (sql != "" ) {
+    if (sql != "") {
       m += "\n<SQL> '" + sql + "'";
     }
     // #432: [R] expects UTF-8 encoded strings but both nanodbc and sql are

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -69,6 +69,7 @@ private:
   int num_columns_;
   bool complete_;
   bool bound_;
+  bool immediate_;
   Iconv output_encoder_;
 
   std::map<short, std::vector<std::string>> strings_;
@@ -83,12 +84,9 @@ private:
 
   // Private method - use only in constructor.
   // It will allocate nanodbc resources ( statement, result )
-  // and call execute or execute_direct as needed.
-  //
-  // @param immediate If false, will prepare and execute
-  // a statement against this-sql_.  If true, will call
-  // nanodbc::statement::execute_direct ( without preparing ).
-  void execute(const bool immediate);
+  // and call execute.
+  void execute();
+
   void bind_columns(
       nanodbc::statement& statement,
       r_type type,

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -24,13 +24,22 @@ public:
       const std::string& sql,
       Iconv& output_encoder)
       : Rcpp::exception("", false) {
-    std::string m = std::string(e.what()) + "\n<SQL> '" + sql + "'";
+    std::string m = std::string(e.what());
+    if (sql != "" ) {
+      m += "\n<SQL> '" + sql + "'";
+    }
     // #432: [R] expects UTF-8 encoded strings but both nanodbc and sql are
     // encoded in the database encoding, which may differ from UTF-8
     message = Rf_translateChar(
         output_encoder.makeSEXP(m.c_str(), m.c_str() + m.length()));
   }
   const char* what() const NANODBC_NOEXCEPT { return message.c_str(); }
+
+  void pretty_print() const {
+    Rcpp::Environment pkg = Rcpp::Environment::namespace_env("odbc");
+    Rcpp::Function rethrow_database_error = pkg["rethrow_database_error"];
+    rethrow_database_error(message);
+  }
 
 private:
   // #432: must be native encoded, as R expects native encoded chars for error msg

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -45,7 +45,6 @@ public:
   std::shared_ptr<nanodbc::statement> statement() const;
   std::shared_ptr<nanodbc::result> result() const;
   void prepare();
-  void execute();
   void describe_parameters(Rcpp::List const& x);
   void bind_list(Rcpp::List const& x, bool use_transaction, size_t batch_rows);
   Rcpp::DataFrame fetch(int n_max = -1);
@@ -82,6 +81,14 @@ private:
   void clear_buffers();
   void unbind_if_needed();
 
+  // Private method - use only in constructor.
+  // It will allocate nanodbc resources ( statement, result )
+  // and call execute or execute_direct as needed.
+  //
+  // @param immediate If false, will prepare and execute
+  // a statement against this-sql_.  If true, will call
+  // nanodbc::statement::execute_direct ( without preparing ).
+  void execute(const bool immediate);
   void bind_columns(
       nanodbc::statement& statement,
       r_type type,

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -50,9 +50,6 @@ void result_bind(result_ptr const& r, List const& params, size_t batch_rows) {
 }
 
 // [[Rcpp::export]]
-void result_execute(result_ptr const& r) { r->execute(); }
-
-// [[Rcpp::export]]
 void result_insert_dataframe(
     result_ptr const& r, DataFrame const& df, size_t batch_rows) {
   r->bind_list(df, true, batch_rows);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -62,7 +62,7 @@ namespace utils {
     if ( rc != 0 )
     {
       // Unable to properly mask SIGINT from execution thread
-      Rcpp::warning("Unexpected behavior when creating execution thread.  Signals to interrupt execution may not be caught.");
+      raise_warning("Unexpected behavior when creating execution thread.  Signals to interrupt execution may not be caught.");
     }
 #endif
     auto future = std::async(std::launch::async, [&exec_fn, &eptr]() {

--- a/src/utils.h
+++ b/src/utils.h
@@ -57,5 +57,11 @@ namespace utils {
   /// \param cleanup_fn Function executed on main thread in the event a
   /// user interrupt is caught.
   void run_interruptible(const std::function<void()>& exec_fn, const std::function<void()>& cleanup_fn);
+
+  /// \brief Entry point form package::odbc:::print_message
+  ///
+  /// \param messge Message to be shown.
+  /// \param is_warning Should displaying this message also generate an [R] warning.
+  void pretty_print_message(const std::string& message, const bool is_warning = false);
 }}
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,6 +7,7 @@
 
 #include <Rcpp.h>
 #include "sql_types.h"
+#include "odbc_result.h"
 #include "nanodbc.h"
 
 namespace odbc {
@@ -44,5 +45,17 @@ namespace utils {
   /// \param token The authentication token.
   /// \return A shared pointer to the buffer containing the serialized structure.
   std::shared_ptr< void > serialize_azure_token( const std::string& token );
+
+  /// \brief Wrapper to allow for interruptible execution of argument function
+  ///
+  /// The execution function is relegated to a separate thread.
+  /// On the main thread, we wait for the execution to complete while
+  /// at the same time checking for user interrupts every one second.
+  ///
+  /// \param exec_fn Function executed on a separate thread.  Exceptions
+  /// are caught and re-thrown on the main thread.
+  /// \param cleanup_fn Function executed on main thread in the event a
+  /// user interrupt is caught.
+  void run_interruptible(const std::function<void()>& exec_fn, const std::function<void()>& cleanup_fn);
 }}
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -58,10 +58,26 @@ namespace utils {
   /// user interrupt is caught.
   void run_interruptible(const std::function<void()>& exec_fn, const std::function<void()>& cleanup_fn);
 
-  /// \brief Entry point form package::odbc:::print_message
+  /// \brief Entry point for package::cli::cli_inform
   ///
-  /// \param messge Message to be shown.
-  /// \param is_warning Should displaying this message also generate an [R] warning.
-  void pretty_print_message(const std::string& message, const bool is_warning = false);
+  /// \param message Message to be shown.
+  void raise_message(const std::string& message);
+
+  /// \brief Entry point for package::cli::cli_warn
+  ///
+  /// \param message Message to be shown.
+  void raise_warning(const std::string& message);
+
+  /// \brief Entry point for package::cli::cli_abort
+  ///
+  /// \param message Message to be shown.
+  void raise_error(const std::string& message);
+
+  /// \brief Entry point for package::odbc:::rethrow_database_error
+  ///
+  /// On the [R] side, the message ( e.what() ) is parsed and
+  /// displayed in a user friendly / multi-line format.
+  /// \param e (nanodbc::database_)Exception to be raised.
+  void raise_error(const odbc_error& e);
 }}
 #endif

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -27,7 +27,7 @@
       Error in `dbConnect()`:
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x Data source name not found and no default driver specified
-      i From 'nanodbc/nanodbc.cpp:1147'.
+      i From 'nanodbc/nanodbc.cpp:1141'.
 
 ---
 
@@ -37,7 +37,7 @@
       Error in `dbExecute()`:
       ! ODBC failed with error 00000 from [SQLite].
       x no such table: boopbopbopbeep (1)
-      i From 'nanodbc/nanodbc.cpp:1719'.
+      i From 'nanodbc/nanodbc.cpp:1713zz'.
 
 # rethrow_database_error() errors well when parse_database_error() fails
 

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -37,6 +37,7 @@
       Error in `dbExecute()`:
       ! ODBC failed with error 00000 from [SQLite].
       x no such table: boopbopbopbeep (1)
+      * <SQL> 'SELECT * FROM boopbopbopbeep'
       i From 'nanodbc/nanodbc.cpp:1713'.
 
 # rethrow_database_error() errors well when parse_database_error() fails

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -37,7 +37,7 @@
       Error in `dbExecute()`:
       ! ODBC failed with error 00000 from [SQLite].
       x no such table: boopbopbopbeep (1)
-      i From 'nanodbc/nanodbc.cpp:1713zz'.
+      i From 'nanodbc/nanodbc.cpp:1713'.
 
 # rethrow_database_error() errors well when parse_database_error() fails
 


### PR DESCRIPTION
Hi All:

Please consider adding this feature - the ability to "Ctrl-C" past a long running query.  For example in SQL Server

```
> dbGetQuery(conn, "WAITFOR DELAY '00:10'", immediate = TRUE);
^C
Caught user interrupt, attempting a clean exit...
Error: nanodbc/nanodbc.cpp:1711: 00000
<SQL> 'WAITFOR DELAY '00:10''
>
```

Some notes - i feel like I am being wordy below but I am sure I still left quite a bit out:

* Design: Created a `run_interruptible` wrapper that takes two arguments: a function to be executed away from the main thread, and a cleanup function to be invoked once the signal is caught on the main thread.  Perhaps this is an overkill but I did this with an eye that maybe some day we may need to be able to interrupt other calls from the `odbc` API, not just `SQLExecute`.  We can then just re-use the wrapper.
* Design: Used `std::async` rather than `std::thread`: I personally am a little biased towards `std::async` but mostly based on semantics.  I know there's quite a bit left up to the implementation but at this point it's been around for long enough that I think there should be little in the way of surprises.  I've witnessed some passionate thread-vs-async discussions before but I think it's mostly a matter of style.  If folks feel strongly one way or another, happy to change it.
* Design: Signal handling ( away from Windows ) - used the `pthread` API to make sure the SIGINT signal is delivered to the main thread.  This is pretty idiosyncratic, but i've seen issues where depending on the implementation, a signal can end up with the wrong thread.
* Opt-out: Struggled with this for a bit.  I am not a fan of `dbConnect` accruing yet more arguments.  At the same time also not in love with introducing some sort of a secret option --- `getOption(.odbc.interruptible.exec)` --- or somesuch.  There is an `attributes` arguments to `dbConnect` but when we introduced it, I think we envisioned `ODBC`/API connection arguments.  So - hated myself a little bit for it - but ended up writing in a new argument to `dbConnect`.
* Testing: Pipelines are (hopefully) passing on both windows and linux and that's a good sign.  Beyond that, on my linux box, I tested DB2, Oracle, Terradata, Databricks and did not see any issues.  Note, the `WAITFOR` style queries are not always interruptible.  For example on `snowflake`, interrupting the equivalent `SELECT system$wait(10)` won't save you any time since the `SQLCancel` call blocks on the main thread after catching the interrupt.  However, testing an actual long running execution I saw better behavior.
  * MySQL: Saw some issues with the MariaDB odbc driver 3.1.15 on Linux.  I went back to installing the driver from their github tree as the behavior is much better with that version ( 3.1.17).  In particular, when using the canned v3.1.15 driver, executing the following will hang execution:
    * `dbSend(Get)Query(conn, NA_character_)` ( part of `DBItest::send(get)_query_non_string` )
    * `dbSendStatement(conn, NA_character_)` ( part of `DBItest::send_statement_non_string` )
    * `dbExecute(conn, NA_character_)` ( part of `DBItest::execute_non_string` )

  Note, all remaining (~3.5K) `DBItest` tests pass with both drivers just fine.  Spent quite a bit of time comparing odbc traces to no avail, and thought it's something **so** idiosyncratic ( and fixed in their newer drivers to boot ) that it should probably not hold this feature back.  Options to ignore were to use newer driver, or to add the tests to the "skip" list for `driver-mysql`.
  
Appreciate any feedback - and thanks for taking a look!