### PR TITLE
Read Workbench-managed Databricks credentials from `databricks.cfg`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,10 @@
   pass `x` to `encodeString()` before returning, for consistency with the
   default implementation in DBI (@simonpcouch, #765).
 
+* `odbc::databricks()` now picks up on Posit Workbench-managed Databricks
+  credentials when rendering Quarto and RMarkdown documents in RStudio
+  (@atheriel, #805).
+
 # odbc 1.4.2
 
 * `dbAppendTable()` Improve performance by checking existence once (#691).


### PR DESCRIPTION
Previously `odbc::databricks()` used `.rs.api.getDatabricksToken()` to check for Workbench-managed credentials, which only works inside the RStudio console. With this commit we look at the generated config file instead, as we do for Snowflake in `odbc::snowflake()`. This gives background jobs and, importantly, the Quarto and RMarkdown rendering panes access to these credentials as well.

Unit tests are included.

Closes #803.