### PR TITLE
ignore GCC `Wdeprecated-declarations` warnings

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -304,12 +304,17 @@ Rcpp::IntegerVector transactionLevels() {
   return out;
 }
 
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 // [[Rcpp::export]]
 void set_transaction_isolation(connection_ptr const& p, size_t level) {
   auto c = (*p)->connection();
   SQLSetConnectAttr(
       c->native_dbc_handle(), SQL_ATTR_TXN_ISOLATION, (SQLPOINTER)level, 0);
 }
+
+# pragma GCC diagnostic pop
 
 // [[Rcpp::export]]
 Rcpp::IntegerVector bigint_mappings() {

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -268,6 +268,8 @@ inline std::size_t strarrlen(T (&a)[N])
     return i;
 }
 
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 inline void convert(const wide_string_type& in, std::string& out)
 {
 #ifdef NANODBC_USE_BOOST_CONVERT
@@ -301,10 +303,8 @@ inline void convert(const wide_string_type& in, std::string& out)
         nullptr,
         nullptr);
 #else
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     out = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().to_bytes(in);
-# pragma GCC diagnostic pop
+
 #endif
 #endif
 #endif


### PR DESCRIPTION
Closes #806 and #808, I think. Expands the existing `# pragma GCC diagnostic ignored "-Wdeprecated-declarations"` to much more cpp code: nearly all of `nanodbc.cpp` and a new section in `connection.cpp`.

Very much open to the idea that this may not be what we want to do long-term, though I believe will do the trick to make a release possible soon (before June 4th, so that new Snowflake wrapper can head out). Will defer to others on whether we ought to file a separate issue and get to work on addressing the use of this deprecated functionality after the upcoming release.