### PR TITLE
Fixup/oracle dates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # odbc (development version)
 
+* oracle: Fix writing to DATE and TIMESTAMP(n) targets using `batch_size` > 1.
+
 * Raises "Cancelling previous query" warnings from R rather than from Rcpp when 
   a connection has a current result to avoid possible incorrect resource 
   unwinds with `options(warn = 2)` (#797).

--- a/R/dbi-table.R
+++ b/R/dbi-table.R
@@ -157,7 +157,7 @@ setMethod("dbAppendTable", "OdbcConnection",
       )
       rs <- OdbcResult(conn, sql)
 
-      if (!is.null(fieldDetails) && nrow(fieldDetails) == nparam) {
+      if (!is.null(fieldDetails) && nrow(fieldDetails) <= nparam) {
         result_describe_parameters(rs@ptr, fieldDetails)
       }
 

--- a/R/driver-oracle.R
+++ b/R/driver-oracle.R
@@ -133,8 +133,12 @@ setMethod("odbcConnectionColumns_", c("Oracle", "character"),
     # are the sizes of nanodbc::date and nanodbc::timestmp in bytes
     # (#349, #350, #391).
     res$data_type <- as.numeric(res$data_type)
-    res[res$field.type == "DATE", c("data_type", "column_size")] <- c(91, 6)
-    res[grepl("TIMESTAMP", res$field.type), c("data_type", "column_size")] <- c(93, 16)
+    isDate <- res$field.type == "DATE"
+    res$data_type[isDate] <- 91
+    res$column_size[isDate] <- 6
+    isTimestamp <- grepl("TIMESTAMP", res$field.type)
+    res$data_type[isTimestamp] <- 93
+    res$column_size[isTimestamp] <- 16
     res
   }
 )

--- a/R/driver-oracle.R
+++ b/R/driver-oracle.R
@@ -122,7 +122,12 @@ setMethod("odbcConnectionColumns_", c("Oracle", "character"),
       )
     }
 
-    dbGetQuery(conn, query)
+    res <- dbGetQuery(conn, query)
+
+    res$data_type <- as.numeric(res$data_type)
+    res[res$`field.type` == "DATE", c("data_type", "column_size")] <- c(91, 6)
+    res[grepl("TIMESTAMP", res$`field.type`), c("data_type", "column_size")] <- c(93, 16)
+    res
   }
 )
 

--- a/R/driver-oracle.R
+++ b/R/driver-oracle.R
@@ -124,9 +124,17 @@ setMethod("odbcConnectionColumns_", c("Oracle", "character"),
 
     res <- dbGetQuery(conn, query)
 
+    # SQLColumns does not correctly describe buffer sizes for date/time
+    # fields ( nor does our custom query above ).  We use these data
+    # as a fallback for SQLDescribeParam ( also incorrectly describes
+    # parameters for ORACLE ) when writing using prepared statements ( see
+    # `dbAppendTable` ).  Fix them here.  91 and 93 are SQL_TYPE_DATE,
+    # and SQL_TYPE_TIMESTAMP, respectively in sql.h.  Six and sixteen
+    # are the sizes of nanodbc::date and nanodbc::timestmp in bytes
+    # (#349, #350, #391).
     res$data_type <- as.numeric(res$data_type)
-    res[res$`field.type` == "DATE", c("data_type", "column_size")] <- c(91, 6)
-    res[grepl("TIMESTAMP", res$`field.type`), c("data_type", "column_size")] <- c(93, 16)
+    res[res$field.type == "DATE", c("data_type", "column_size")] <- c(91, 6)
+    res[grepl("TIMESTAMP", res$field.type), c("data_type", "column_size")] <- c(93, 16)
     res
   }
 )

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -1874,7 +1874,6 @@ public:
         disable_async();
 #endif
 
-        // TODO: Check if we have param_descr_data_
         NANODBC_CALL_RC(
             SQLDescribeParam,
             rc,
@@ -1949,7 +1948,6 @@ public:
                 param.size_ = 255;
                 param.scale_ = 0;
             }
-            // TODO: populate param_descr_data
         }
         else
         {

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -1874,6 +1874,7 @@ public:
         disable_async();
 #endif
 
+        // TODO: Check if we have param_descr_data_
         NANODBC_CALL_RC(
             SQLDescribeParam,
             rc,
@@ -1948,6 +1949,7 @@ public:
                 param.size_ = 255;
                 param.scale_ = 0;
             }
+            // TODO: populate param_descr_data
         }
         else
         {

--- a/tests/testthat/test-driver-oracle.R
+++ b/tests/testthat/test-driver-oracle.R
@@ -24,13 +24,12 @@ test_that("Writing date/datetime with batch size > 1", {
   # See #349, #350, #391
   con <- test_con("ORACLE")
 
-  ir <- datasets::iris
   values <- data.frame(
-    datetime = as.POSIXct(as.numeric(ir$Petal.Length * 10), origin = "2024-01-01", tz = "UTC"),
-    date    = as.Date(as.numeric(ir$Petal.Length * 10), origin = "2024-01-01", tz = "UTC"),
-    integer = as.integer(ir$Petal.Width * 100),
-    double = ir$Sepal.Length,
-    varchar = ir$Species)
+    datetime = as.POSIXct(as.numeric(iris$Petal.Length * 10), origin = "2024-01-01", tz = "UTC"),
+    date    = as.Date(as.numeric(iris$Petal.Length * 10), origin = "2024-01-01", tz = "UTC"),
+    integer = as.integer(iris$Petal.Width * 100),
+    double = iris$Sepal.Length,
+    varchar = iris$Species)
   tbl <- local_table(con, "test_batched_write_w_dates", values)
   res <- dbReadTable(con, "test_batched_write_w_dates")
   expect_true(nrow(res) == nrow(values))


### PR DESCRIPTION
Fixes long-standing ORACLE issues with using batch sizes greater than one when writing to tables with DATE and TIMESTAMP fields.

See, for example #349, #350, #391