### PR TITLE
v1.5.0 release candidate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odbc
 Title: Connect to ODBC Compatible Databases (using the DBI Interface)
-Version: 1.4.2.9000
+Version: 1.5.0
 Authors@R: c(
     person("Jim", "Hester", role = "aut"),
     person("Hadley", "Wickham", , "hadley@posit.co", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,28 +1,27 @@
-# odbc (development version)
+# odbc 1.4.3
 
-* Long running queries can now be interrupted using Ctrl-C.  This
-  feature is enabled by default in interactive sessions.  It can be
-  controlled by the `interruptible` argument to `dbConnect`, or by the
-  global option `odbc.interruptible`.  Should be considered experimental -
-  if you experience problems please file an issue on the package github
+## Major changes
+
+* New function `snowflake()` makes it easier to connect to Snowflake, 
+  automatically handling authentication correctly on platforms that provide 
+  Snowflake-native OAuth credentials (@atheriel, #662).
+    
+* Long running queries can now be interrupted using Ctrl-C. This
+  feature is enabled by default in interactive sessions. It can be
+  controlled by the `interruptible` argument to `dbConnect()` or by the
+  global option `odbc.interruptible`. Should be considered experimental---if
+  you experience problems please file an issue on the package's GitHub
   repository (#796).
+
+## Minor improvements and bug fixes
+
+* Improved argument checking and transitioned to the cli package for 
+  formatting most existing error messages (@simonpcouch, #781, #784, #785, #788).
 
 * Raises "Cancelling previous query" warnings from R rather than from Rcpp when 
   a connection has a current result to avoid possible incorrect resource 
   unwinds with `options(warn = 2)` (#797).
-
-* New `odbc::snowflake()` makes it easier to connect to Snowflake, 
-  automatically handling authentication correctly on platforms that provide 
-  Snowflake-native OAuth credentials (@atheriel, #662).
-
-* Transitioned to the cli package for formatting most error messages 
-  (@simonpcouch, #781, #784, #785, #788).
-
-* `databricks()` will now automatically configure the needed driver and driver
-  manager on macOS (#651).
-
-* Snowflake: Improved performance on write (#760).
-
+  
 * Adjusted the default `batch_rows` value for `dbWriteTable()` and `dbBind()` 
   methods. odbc 1.3.0 changed the default value from 1024 to `NA`, which sets the 
   batch size to be the length of the input. While this addressed issues for
@@ -31,26 +30,39 @@
   drivers. The package will now interpet `NA` as the minimum of 1024 and the 
   length of the input (@simonpcouch, #774).
 
-* odbc now always converts the encoding of non-ASCII column names of the SQL
-  results to UTF-8. (@shrektan, #430)
+* The encoding of non-ASCII column names of SQL results is now always converted
+  to UTF-8. (@shrektan, #430)
 
-* Fixed issue that odbc may throw errors with garbage letters when the encoding
-  of client and db-server are different. (@shrektan, #432)
+* Improved error messages when the encoding of client and db-server are 
+  different. (@shrektan, #432)
 
-* dbListFields: Now works with DBI::Id and DBI::SQL identifiers.
+* `dbListFields()` now works with `Id()` and `SQL()` identifiers (#771).
 
 * Transitioned `odbcDataType()` to use S4 for consistency. S3 methods defined
-  locally will need to be rewritten (#701).
-
-* Teradata: Resolved issue when previewing tables using the Connections pane.
+  locally will need to be rewritten (@simonpcouch, #701).
 
 * The `"OdbcConnection"` method for `dbQuoteIdentifier()` will no longer 
   pass `x` to `encodeString()` before returning, for consistency with the
   default implementation in DBI (@simonpcouch, #765).
 
-* `odbc::databricks()` now picks up on Posit Workbench-managed Databricks
+* A bug in the implementation of a new feature introduced in 1.4.2, where the
+  package would automatically set the `ODBCSYSINI` environmental variable when 
+  using the unixODBC driver manager, was fixed; that environmental variable
+  will now actually be set on package load (@simonpcouch, #792).
+
+## Driver specific changes
+
+* `databricks()` will now automatically configure the needed driver and driver
+  manager on macOS (@simonpcouch, #651).
+
+* `databricks()` now picks up on Posit Workbench-managed Databricks
   credentials when rendering Quarto and RMarkdown documents in RStudio
   (@atheriel, #805).
+  
+* Improved performance on write with Snowflake (#760).
+
+* Resolved issue when previewing tables using the RStudio Connections pane with 
+  Teradata (@simonpcouch, #755).
 
 # odbc 1.4.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -223,7 +223,8 @@
 * When calling `sqlCreateTable(con, ..., temporary = TRUE)` and `con` is a
   connection of class `DB2/AIX64`, the `CREATE TABLE` statement that is generated
   properly creates a temporary table in DB2. The statement begins with
-  [`DECLARE GLOBAL TEMPORARY TABLE`](https://www.ibm.com/docs/SSEPEK_11.0.0/sqlref/src/tpc/db2z_sql_declareglobaltemptable.html)
+  `DECLARE GLOBAL TEMPORARY TABLE` at
+  `https://www.ibm.com/docs/SSEPEK_11.0.0/sqlref/src/tpc/db2z_sql_declareglobaltemptable.html`
   and ends with `ON COMMIT PRESERVE ROWS` (DB2's default behavior is
   `ON COMMIT DELETE ROWS`, which results in the inserted data being
   deleted as soon as `dbWriteTable` completes). (@rnorberg, #426)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# odbc 1.4.3
+# odbc 1.5.0
 
 ## Major changes
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/r-dbi/odbc/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-dbi/odbc?branch=main)
 <!-- badges: end -->
 
-The goal of the odbc package is to provide a [DBI](https://dbi.r-dbi.org/)-compliant interface to [ODBC](https://learn.microsoft.com/en-us/sql/odbc/microsoft-open-database-connectivity-odbc) drivers. This makes it easy to connect databases such as [SQL Server](https://www.microsoft.com/en-us/sql-server/), Oracle, [Databricks](https://www.databricks.com/), and [Snowflake](https://www.snowflake.com/en/).
+The goal of the odbc package is to provide a [DBI](https://dbi.r-dbi.org/)-compliant interface to [ODBC](https://learn.microsoft.com/en-us/sql/odbc/microsoft-open-database-connectivity-odbc) drivers. This makes it easy to connect databases such as [SQL Server](https://www.microsoft.com/en-us/sql-server/), Oracle, [Databricks](https://www.databricks.com/), and Snowflake.
 
 The odbc package is an alternative to
 [RODBC](https://cran.r-project.org/package=RODBC) and [RODBCDBI](https://cran.r-project.org/package=RODBCDBI) packages, and is typically much faster. See `vignette("benchmarks")` to learn more.

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/r-dbi/odbc/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-dbi/odbc?branch=main)
 <!-- badges: end -->
 
-The goal of the odbc package is to provide a [DBI](https://dbi.r-dbi.org/)-compliant interface to [ODBC](https://learn.microsoft.com/en-us/sql/odbc/microsoft-open-database-connectivity-odbc) drivers. This makes it easy to connect databases such as [SQL Server](https://www.microsoft.com/en-us/sql-server/), [Oracle](https://www.oracle.com/database/technologies/), [Databricks](https://www.databricks.com/), and [Snowflake](https://www.snowflake.com/en/).
+The goal of the odbc package is to provide a [DBI](https://dbi.r-dbi.org/)-compliant interface to [ODBC](https://learn.microsoft.com/en-us/sql/odbc/microsoft-open-database-connectivity-odbc) drivers. This makes it easy to connect databases such as [SQL Server](https://www.microsoft.com/en-us/sql-server/), Oracle, [Databricks](https://www.databricks.com/), and [Snowflake](https://www.snowflake.com/en/).
 
 The odbc package is an alternative to
 [RODBC](https://cran.r-project.org/package=RODBC) and [RODBCDBI](https://cran.r-project.org/package=RODBCDBI) packages, and is typically much faster. See `vignette("benchmarks")` to learn more.

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/r-dbi/odbc/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-dbi/odbc?branch=main)
 <!-- badges: end -->
 
-The goal of the odbc package is to provide a [DBI](https://dbi.r-dbi.org/)-compliant interface to [ODBC](https://learn.microsoft.com/en-us/sql/odbc/microsoft-open-database-connectivity-odbc) drivers. This makes it easy to connect databases such as [SQL Server](https://www.microsoft.com/en-us/sql-server/), [Oracle](https://www.oracle.com/database), [Databricks](https://www.databricks.com/), and [Snowflake](https://www.snowflake.com/en/).
+The goal of the odbc package is to provide a [DBI](https://dbi.r-dbi.org/)-compliant interface to [ODBC](https://learn.microsoft.com/en-us/sql/odbc/microsoft-open-database-connectivity-odbc) drivers. This makes it easy to connect databases such as [SQL Server](https://www.microsoft.com/en-us/sql-server/), [Oracle](https://www.oracle.com/database/technologies/), [Databricks](https://www.databricks.com/), and [Snowflake](https://www.snowflake.com/en/).
 
 The odbc package is an alternative to
 [RODBC](https://cran.r-project.org/package=RODBC) and [RODBCDBI](https://cran.r-project.org/package=RODBCDBI) packages, and is typically much faster. See `vignette("benchmarks")` to learn more.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ drivers. This makes it easy to connect databases such as [SQL
 Server](https://www.microsoft.com/en-us/sql-server/),
 Oracle,
 [Databricks](https://www.databricks.com/), and
-[Snowflake](https://www.snowflake.com/en/).
+Snowflake.
 
 The odbc package is an alternative to
 [RODBC](https://cran.r-project.org/package=RODBC) and

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The goal of the odbc package is to provide a
 [ODBC](https://learn.microsoft.com/en-us/sql/odbc/microsoft-open-database-connectivity-odbc)
 drivers. This makes it easy to connect databases such as [SQL
 Server](https://www.microsoft.com/en-us/sql-server/),
-[Oracle](https://www.oracle.com/database),
+Oracle,
 [Databricks](https://www.databricks.com/), and
 [Snowflake](https://www.snowflake.com/en/).
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,10 +1,12 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 0 notes
+Recent MacOS builds have trigger the NOTE "installed size is 10.8Mb." MacOS builds include all debug symbols and CRAN policy doesn't permit building without them.
+
+"Additional issues" checks on M1 Mac surface a number of new warnings related to GCC SQL/ODBC deprecations resulting from `sys-iodbc` headers overwriting `unixodbc` headers in `R-macos/recipes` (see https://github.com/R-macos/recipes/issues/41 and linked issues).
 
 ## revdepcheck results
 
-We checked 28 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+We checked 32 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
  * We failed to check 0 packages

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,6 +1,6 @@
 ## revdepcheck results
 
-We checked 28 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+We checked 32 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
  * We failed to check 0 packages

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -84,6 +84,7 @@ test_that("parse_database_error() works with messages from the wild", {
 })
 
 test_that("set_odbcsysini() works (#791)", {
+  skip_on_cran()
   skip_if(is_windows())
 
   expect_false(identical(Sys.getenv("ODBCSYSINI"), ""))

--- a/vignettes/develop.Rmd
+++ b/vignettes/develop.Rmd
@@ -22,7 +22,7 @@ For the most part, this vignette assumes a MacOS system with aarch64 (e.g. M1 or
 
 ## Posit Professional Drivers
 
-Posit employees have access to the [Posit Professional drivers](https://docs.posit.co/pro-drivers/) and the infrastructure used to build and test them in the [rstudio/pro-drivers](https://github.com/rstudio/pro-drivers) repo. The Posit Professional drivers are a set of drivers vendored from Magnitude Simba that support many of the most popular DBMS, including SQL Server, Oracle, Redshift, Databricks, Snowflake, etc. The repository they're developed in contains tooling to spin up a number of databases in docker containers to test against.
+Posit employees have access to the [Posit Professional drivers](https://docs.posit.co/pro-drivers/) and the infrastructure used to build and test them in the rstudio/pro-drivers GitHub repository. The Posit Professional drivers are a set of drivers vendored from Magnitude Simba that support many of the most popular DBMS, including SQL Server, Oracle, Redshift, Databricks, Snowflake, etc. The repository they're developed in contains tooling to spin up a number of databases in docker containers to test against.
 
 Note that Athena, Hive, Impala, MongoDB, and Oracle drivers are [not available for macOS aarch64](https://github.com/oracle/python-cx_Oracle/issues/617) (M1, M2, etc) at the time of writing.
 
@@ -32,7 +32,7 @@ The only documented installation method for these drivers on MacOS is via RStudi
 
 ### Databases
 
-Among other things, the [rstudio/pro-drivers](https://github.com/rstudio/pro-drivers) repo defines a `MAKE` tool for setting up and tearing down databases in docker containers. Ensure that you have a docker daemon running (i.e. Docker Desktop open) and, if you're on macOS aarch64, have `Settings > Use Rosetta for x86_64/amd64 emulation on Apple Silicon` enabled. To start a container for a given `dbms`, run `MAKE dist=none DB=dbms up`, and **tear it down** with `MAKE dist=none DB=db down`. To see available `dbms` options, see the names of `.yml` files in the `docker-compose` directory. Find connection details for each database in `docker/shared/odbc.ini`.
+Among other things, the rstudio/pro-drivers GitHub repository defines a `MAKE` tool for setting up and tearing down databases in docker containers. Ensure that you have a docker daemon running (i.e. Docker Desktop open) and, if you're on macOS aarch64, have `Settings > Use Rosetta for x86_64/amd64 emulation on Apple Silicon` enabled. To start a container for a given `dbms`, run `MAKE dist=none DB=dbms up`, and **tear it down** with `MAKE dist=none DB=db down`. To see available `dbms` options, see the names of `.yml` files in the `docker-compose` directory. Find connection details for each database in `docker/shared/odbc.ini`.
 
 DBMS-specific notes:
 
@@ -313,7 +313,7 @@ In the above, the password has been set as `Sys.setenv(snowflakePass = "actualPa
 
 ## Amazon Redshift
 
-If you're a Posit employee, you should have access to the [https://github.com/rstudio/warehouse](https://github.com/rstudio/warehouse) repository. Follow the instructions there to get access to the internal Redshift cluster. Access to the cluster is only enabled through Posit's internal Workbench instance, where the professional drivers will already be installed.
+If you're a Posit employee, you should have access to the rstudio/warehouse GitHub repository. Follow the instructions there to get access to the internal Redshift cluster. Access to the cluster is only enabled through Posit's internal Workbench instance, where the professional drivers will already be installed.
 
 Note that Redshift is based on a modified version of PostgreSQL.
 


### PR DESCRIPTION
Closes #811, closes #807. Two notes:

* I wasn't sure whether to make this release patch or minor, and
* Needs a version bump in DESCRIPTION before submission.

Depending on where the Snowflake migration is at, these may be the first GHA to fail. The offending tests use:

```r
  pwd <- Sys.getenv("ODBC_PWD_SNOWFLAKE")
  if (nchar(pwd) == 0) {
    skip("Secret ODBC_PWD_SNOWFLAKE not available.")
  }
```

...so will not be an issue on CRAN.