### PR TITLE
revert default `batch_rows` to size of input data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # odbc (development version)
 
+* Reverted a change to the default `batch_rows` value for `dbWriteTable()` and 
+  `dbBind()` that resulted in write errors for some drivers. The default
+  `batch_size` is once again the length of the input (@simonpcouch, #813, #814).
+
 # odbc 1.5.0
 
 ## Major changes

--- a/R/dbi-table.R
+++ b/R/dbi-table.R
@@ -101,9 +101,9 @@ odbc_write_table <- function(conn,
 #' @param append Allow appending to the destination table. Cannot be
 #'   `TRUE` if `overwrite` is also `TRUE`.
 #' @param batch_rows The number of rows to retrieve. Defaults to `NA`, which
-#'   is set dynamically to the minimum of 1024 and the size of the input.
-#'   Depending on the database, driver, dataset and free memory, setting this
-#'   to a lower value may improve performance.
+#'   is set dynamically to the size of the input. Depending on the database,
+#'   driver, dataset and free memory setting this to a lower value may improve
+#'   performance.
 #' @export
 setMethod("dbWriteTable", c("OdbcConnection", "character", "data.frame"),
   odbc_write_table
@@ -167,7 +167,6 @@ setMethod("dbAppendTable", "OdbcConnection",
         if (batch_rows == 0) {
           batch_rows <- 1
         }
-        batch_rows <- min(1024, batch_rows)
       }
       batch_rows <- parse_size(batch_rows)
       tryCatch(

--- a/man/DBI-tables.Rd
+++ b/man/DBI-tables.Rd
@@ -83,7 +83,7 @@ just any valid bare table name.}
 \item{append}{Allow appending to the destination table. Cannot be
 \code{TRUE} if \code{overwrite} is also \code{TRUE}.}
 
-\item{temporary}{If \code{TRUE}, will generate a temporary table statement.}
+\item{temporary}{If \code{TRUE}, will generate a temporary table.}
 
 \item{row.names}{Either \code{TRUE}, \code{FALSE}, \code{NA} or a string.
 
@@ -99,9 +99,9 @@ For backward compatibility, \code{NULL} is equivalent to \code{FALSE}.}
 \item{field.types}{Additional field types used to override derived types.}
 
 \item{batch_rows}{The number of rows to retrieve. Defaults to \code{NA}, which
-is set dynamically to the minimum of 1024 and the size of the input.
-Depending on the database, driver, dataset and free memory setting this
-to a lower value may improve performance.}
+is set dynamically to the size of the input. Depending on the database,
+driver, dataset and free memory setting this to a lower value may improve
+performance.}
 
 \item{...}{Other arguments used by individual methods.}
 

--- a/man/OdbcResult.Rd
+++ b/man/OdbcResult.Rd
@@ -53,9 +53,9 @@ For \code{dbBindArrow()}, values as a nanoarrow stream,
 with one column per query parameter.}
 
 \item{batch_rows}{The number of rows to retrieve. Defaults to \code{NA}, which
-is set dynamically to the minimum of 1024 and the size of the input.
-Depending on the database, driver, dataset and free memory, setting this
-to a lower value may improve performance.}
+is set dynamically to the size of the input. Depending on the database,
+driver, dataset and free memory setting this to a lower value may improve
+performance.}
 }
 \description{
 Implementations of pure virtual functions defined in the \code{DBI} package


### PR DESCRIPTION
Closes #814 and (possibly?) closes #813. A bit more information in #814 threads.