### PR TITLE
transition to JWT for snowflake authentication

### DIFF
--- a/.github/odbc/odbc.ini
+++ b/.github/odbc/odbc.ini
@@ -43,11 +43,11 @@ Description = Oracle
 Driver = Oracle 21 ODBC driver
 Port = 1521
 
+; note that db.yaml GHA requires that this is the last DSN entry
 [snowflake]
 Description=SnowflakeDB
 Driver=SnowflakeDSIIDriver
 Locale=en-US
-SERVER=uab99020.us-east-1.snowflakecomputing.com
-PORT=443
-SSL=on
-uid=odbcTestRunner
+SERVER=duloftf-posit-software-pbc-dev.snowflakecomputing.com
+uid=SVC_RDBI_ODBC
+Authenticator=snowflake_jwt

--- a/.github/workflows/db.yaml
+++ b/.github/workflows/db.yaml
@@ -104,6 +104,13 @@ jobs:
           echo "CABundleFile=$ODBCSYSINI/snowflake_odbc/lib/cacert.pem" >> .github/odbc/snowflake_odbc/lib/simba.snowflake.ini
           echo "ErrorMessagesPath=$ODBCSYSINI/snowflake_odbc/ErrorMessages/" >> .github/odbc/snowflake_odbc/lib/simba.snowflake.ini
 
+      # note that this assumes Snowflake is the last odbc.ini entry
+      - name: Prepare Snowflake private key
+        run: |
+          echo "${{ secrets.SNOWFLAKE_PRIVATE_KEY }}" > $ODBCSYSINI/private_key.pem
+          echo "PRIV_KEY_FILE=$ODBCSYSINI/private_key.pem" | tee -a $ODBCSYSINI/odbc.ini
+          export SNOWFLAKE_PRIVATE_KEY_EXISTS=TRUE
+
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/tests/testthat/test-driver-snowflake.R
+++ b/tests/testthat/test-driver-snowflake.R
@@ -1,7 +1,7 @@
 test_that("can connect to snowflake", {
-  pwd <- Sys.getenv("ODBC_PWD_SNOWFLAKE")
-  if (nchar(pwd) == 0) {
-    skip("Secret ODBC_PWD_SNOWFLAKE not available.")
+  key_exists <- Sys.getenv("SNOWFLAKE_PRIVATE_KEY_EXISTS")
+  if (nchar(key_exists) == 0) {
+    skip("Secret SNOWFLAKE_PRIVATE_KEY not available.")
   }
 
   con <- test_con("SNOWFLAKE")
@@ -145,19 +145,5 @@ test_that("Workbench-managed credentials are ignored for other accounts", {
   expect_snapshot(
     snowflake_args(account = "testorg-test_account", driver = "driver"),
     error = TRUE
-  )
-})
-
-test_that("snowflake() works against a real account", {
-  pwd <- Sys.getenv("ODBC_PWD_SNOWFLAKE")
-  if (nchar(pwd) == 0) {
-    skip("Secret ODBC_PWD_SNOWFLAKE not available.")
-  }
-  dbConnect(
-    odbc::snowflake(),
-    account = "uab99020.us-east-1",
-    driver = "SnowflakeDSIIDriver",
-    uid = "odbcTestRunner",
-    pwd = pwd
   )
 })


### PR DESCRIPTION
Folks working on the Snowflake integration at Posit recently transitioned to a different auth system for our dev instance. This PR sets up auth via JWT using a repository secret `SNOWFLAKE_PRIVATE_KEY`.

This should be enough to once again get CI passing. :)