### PR TITLE
check for unixODBC in `dbConnect(odbc(), ...)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* `dbConnect(odbc(), ....)` will now error informatively if the package
+  can't locate a unixODBC install on MacOS and Linux (@simonpcouch, #782).
+
 * Added a hex logo for the package (@edgararuiz, #824).
 
 * oracle: Fix writing to DATE and TIMESTAMP(n) targets using `batch_size` > 1.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # odbc (development version)
 
-* `dbConnect(odbc(), ....)` will now error informatively if the package
+* `dbConnect(odbc(), ...)` will now error informatively if the package
   can't locate a unixODBC install on MacOS and Linux (@simonpcouch, #782).
 
 * Added a hex logo for the package (@edgararuiz, #824).

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -188,8 +188,7 @@ setMethod("dbConnect", "OdbcDriver",
     check_string(dbms.name, allow_null = TRUE)
     check_bool(interruptible)
 
-    unixodbc_install <- locate_install_unixodbc()
-    if (length(unixodbc_install) == 0) {
+    if (!is_windows() && length(locate_install_unixodbc()) == 0) {
       error_install_unixodbc(call = caller_env())
     }
 

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -188,6 +188,11 @@ setMethod("dbConnect", "OdbcDriver",
     check_string(dbms.name, allow_null = TRUE)
     check_bool(interruptible)
 
+    unixodbc_install <- locate_install_unixodbc()
+    if (length(unixodbc_install) == 0) {
+      error_install_unixodbc(call = caller_env())
+    }
+
     con <- OdbcConnection(
       dsn = dsn,
       ...,

--- a/R/utils.R
+++ b/R/utils.R
@@ -252,15 +252,8 @@ configure_spark <- function(call = caller_env()) {
     return(invisible())
   }
 
-  unixodbc_install <- locate_install_unixodbc()
-  if (length(unixodbc_install) == 0) {
-    abort(
-      c(
-        "Unable to locate the unixODBC driver manager.",
-        i = "Please install unixODBC using Homebrew with `brew install unixodbc`."
-      ),
-      call = call
-    )
+  if (length(locate_install_unixodbc()) == 0) {
+    error_install_unixodbc(call)
   }
 
   spark_config <- locate_config_spark()
@@ -296,6 +289,16 @@ locate_install_unixodbc <- function() {
     common_dirs,
     pattern = "libodbcinst\\.dylib$",
     full.names = TRUE
+  )
+}
+
+error_install_unixodbc <- function(call) {
+  abort(
+    c(
+      "Unable to locate the unixODBC driver manager.",
+      i = "Please install unixODBC using Homebrew with `brew install unixodbc`."
+    ),
+    call = call
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -291,7 +291,7 @@ locate_install_unixodbc <- function() {
 
   list.files(
     common_dirs,
-    pattern = "libodbcinst\\.(dylib|so)$",
+    pattern = libodbcinst_filename(),
     full.names = TRUE
   )
 }
@@ -300,7 +300,7 @@ system_safely <- function(x) {
   tryCatch(
     {
       unixodbc_prefix <- system(x, intern = TRUE, ignore.stderr = TRUE)
-      return(paste0(unixodbc_prefix, "/libodbcinst.", libodbcinst_extension()))
+      return(paste0(unixodbc_prefix, "/", libodbcinst_filename()))
     },
     error = function(e) {},
     warning = function(w) {}
@@ -308,29 +308,23 @@ system_safely <- function(x) {
   character()
 }
 
-libodbcinst_extension <- function() {
+libodbcinst_filename <- function() {
   if (is_macos()) {
-    return("dylib")
+    "libodbcinst.dylib"
+  } else {
+    "libodbcinst.so"
   }
-  return("so")
 }
 
 error_install_unixodbc <- function(call) {
   abort(
     c(
       "Unable to locate the unixODBC driver manager.",
-      i = prompt_install_unixodbc()
+      i = if (is_macos()) "Please install unixODBC using Homebrew with `brew install unixodbc`.",
+      i = if (!is_macos()) "Please install unixODBC and retry."
     ),
     call = call
   )
-}
-
-prompt_install_unixodbc <- function() {
-  if (is_macos()) {
-    return("Please install unixODBC using Homebrew with `brew install unixodbc`.")
-  }
-
-  "Please install unixODBC and retry."
 }
 
 # p. 44 https://downloads.datastax.com/odbc/2.6.5.1005/Simba%20Spark%20ODBC%20Install%20and%20Configuration%20Guide.pdf

--- a/tests/testthat/_snaps/Darwin/dbi-connection.md
+++ b/tests/testthat/_snaps/Darwin/dbi-connection.md
@@ -1,0 +1,9 @@
+# dbConnect() errors informatively without unixODBC (#782)
+
+    Code
+      test_con("SQLITE")
+    Condition
+      Error in `dbConnect()`:
+      ! Unable to locate the unixODBC driver manager.
+      i Please install unixODBC using Homebrew with `brew install unixodbc`.
+

--- a/tests/testthat/_snaps/Linux/dbi-connection.md
+++ b/tests/testthat/_snaps/Linux/dbi-connection.md
@@ -1,0 +1,9 @@
+# dbConnect() errors informatively without unixODBC (#782)
+
+    Code
+      test_con("SQLITE")
+    Condition
+      Error in `dbConnect()`:
+      ! Unable to locate the unixODBC driver manager.
+      i Please install unixODBC and retry.
+

--- a/tests/testthat/_snaps/dbi-connection.md
+++ b/tests/testthat/_snaps/dbi-connection.md
@@ -28,12 +28,3 @@
       Error in `dbQuoteIdentifier()`:
       ! `x` can't be `NA`.
 
-# dbConnect() errors informatively without unixODBC (#782)
-
-    Code
-      test_con("SQLITE")
-    Condition
-      Error in `dbConnect()`:
-      ! Unable to locate the unixODBC driver manager.
-      i Please install unixODBC using Homebrew with `brew install unixodbc`.
-

--- a/tests/testthat/_snaps/dbi-connection.md
+++ b/tests/testthat/_snaps/dbi-connection.md
@@ -28,3 +28,12 @@
       Error in `dbQuoteIdentifier()`:
       ! `x` can't be `NA`.
 
+# dbConnect() errors informatively without unixODBC (#782)
+
+    Code
+      test_con("SQLITE")
+    Condition
+      Error in `dbConnect()`:
+      ! Unable to locate the unixODBC driver manager.
+      i Please install unixODBC using Homebrew with `brew install unixodbc`.
+

--- a/tests/testthat/test-dbi-connection.R
+++ b/tests/testthat/test-dbi-connection.R
@@ -36,8 +36,9 @@ test_that("dbQuoteIdentifier() errors informatively", {
 })
 
 test_that("dbConnect() errors informatively without unixODBC (#782)", {
+  skip_on_os("windows")
   local_mocked_bindings(
     locate_install_unixodbc = function(...) {character()}
   )
-  expect_snapshot(error = TRUE, test_con("SQLITE"))
+  expect_snapshot(error = TRUE, test_con("SQLITE"), variant = Sys.info()[["sysname"]])
 })

--- a/tests/testthat/test-dbi-connection.R
+++ b/tests/testthat/test-dbi-connection.R
@@ -34,3 +34,10 @@ test_that("dbQuoteIdentifier() errors informatively", {
     dbQuoteIdentifier(con, NA_character_)
   )
 })
+
+test_that("dbConnect() errors informatively without unixODBC (#782)", {
+  local_mocked_bindings(
+    locate_install_unixodbc = function(...) {character()}
+  )
+  expect_snapshot(error = TRUE, test_con("SQLITE"))
+})


### PR DESCRIPTION
This PR adds a call to `locate_install_unixodbc()` to the main connection path, now that we've "piloted" it in the macOS x Databricks connection path for a release without issue. Closes #782.