### PR TITLE
allow `uid` without `pwd` for `"externalbrowser"` snowflake auth

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* `snowflake()` now allows passing `uid` without `pwd` when 
+  `authenticator = "externalbrowser"` (@simonpcouch, #817).
+
 * DB2: Better support for temp tables in `dbListTables`, and `dbExistsTable` (#823).
 
 * `dbConnect(odbc(), ...)` will now error informatively if the package

--- a/R/driver-snowflake.R
+++ b/R/driver-snowflake.R
@@ -267,7 +267,9 @@ snowflake_auth_args <- function(account,
                                 pwd = NULL,
                                 authenticator = NULL,
                                 ...) {
-  if (!is.null(uid) && !is.null(pwd)) {
+  if (!is.null(uid) &&
+      # allow for uid without pwd for externalbrowser auth (#817)
+      (!is.null(pwd) || identical(authenticator, "externalbrowser"))) {
     return(list(uid = uid, pwd = pwd))
   } else if (xor(is.null(uid), is.null(pwd))) {
     abort(

--- a/tests/testthat/test-driver-snowflake.R
+++ b/tests/testthat/test-driver-snowflake.R
@@ -76,6 +76,17 @@ test_that("alternative authenticators are supported", {
   expect_equal(args$authenticator, "externalbrowser")
 })
 
+test_that("can pass only `uid` with `authenticator = 'externalbrowser'` (#817)", {
+  args <- snowflake_args(
+    account = "testorg-test_account",
+    driver = "driver",
+    authenticator = "externalbrowser",
+    uid = "boop"
+  )
+  expect_equal(args$uid, "boop")
+  expect_equal(args$authenticator, "externalbrowser")
+})
+
 test_that("we error if we can't find ambient credentials", {
   withr::local_envvar(SF_PARTNER = "")
   local_mocked_bindings(


### PR DESCRIPTION
Closes #817.