### PR TITLE
remove trailing slashes from `databricks(workspace)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* Trailing slashes are now automatically removed from `databricks(workspace)`,
+  guarding users from an uninformative driver message (@simonpcouch, #827).
+
 * `snowflake()` now allows passing `uid` without `pwd` when 
   `authenticator = "externalbrowser"` (@simonpcouch, #817).
 

--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -187,7 +187,7 @@ databricks_host <- function(workspace) {
       call = quote(DBI::dbConnect())
     )
   }
-  gsub("https://", "", workspace)
+  gsub("https://|/$", "", workspace)
 }
 
 #' @importFrom utils packageVersion

--- a/tests/testthat/test-driver-databricks.R
+++ b/tests/testthat/test-driver-databricks.R
@@ -38,6 +38,8 @@ test_that("errors if can't find driver", {
 
 test_that("databricks host validates inputs", {
   expect_equal(databricks_host("https://my-host.com"), "my-host.com")
+  expect_equal(databricks_host("https://my-host.com/"), "my-host.com")
+  expect_equal(databricks_host("my-host.com/"), "my-host.com")
   expect_snapshot(databricks_host(""), error = TRUE)
 })
 


### PR DESCRIPTION
Closes #827.