### PR TITLE
add context to "Data source name not found..." error

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -214,7 +214,7 @@ contextualize_database_error <- function(cnd_body) {
     cnd_body <-
       c(
         cnd_body,
-        "See {.help [?odbcListDataSources](odbc::odbcListDataSources)} to learn more."
+        "See {.help odbc::odbcListDataSources} to learn more."
       )
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -199,12 +199,26 @@ parse_database_error <- function(msg) {
     right = TRUE
   )
 
+  cnd_body <- contextualize_database_error(cnd_body)
+
   list(
     cnd_context_nanodbc = cnd_context_nanodbc,
     cnd_context_code = cnd_context_code,
     cnd_context_driver = cnd_context_driver,
     cnd_body = cnd_body
   )
+}
+
+contextualize_database_error <- function(cnd_body) {
+  if (any(grepl("Data source name not found", cnd_body))) {
+    cnd_body <-
+      c(
+        cnd_body,
+        "See {.help [?odbcListDataSources](odbc::odbcListDataSources)} to learn more."
+      )
+  }
+
+  cnd_body
 }
 
 # check helpers for common odbc arguments --------------------------------------

--- a/R/utils.R
+++ b/R/utils.R
@@ -169,7 +169,7 @@ rethrow_database_error <- function(msg, call = trace_back()$call[[1]]) {
     c(
       "!" = "ODBC failed with error {res$cnd_context_code} from \\
              {.field {paste0(res$cnd_context_driver, collapse = '')}}.",
-      set_names(res$cnd_body, nm = c("x", rep("*", length(res$cnd_body) - 1))),
+      set_database_error_names(res$cnd_body),
       "i" = "From {.file {res$cnd_context_nanodbc}}."
     ),
     class = "odbc_database_error",
@@ -210,15 +210,41 @@ parse_database_error <- function(msg) {
 }
 
 contextualize_database_error <- function(cnd_body) {
+  if (length(cnd_body) == 0 || !is_character(cnd_body)) {
+    return(cnd_body)
+  }
+
   if (any(grepl("Data source name not found", cnd_body))) {
     cnd_body <-
       c(
         cnd_body,
-        "See {.help odbc::odbcListDataSources} to learn more."
+        "i" = "See {.help odbc::odbcListDataSources} to learn more."
       )
   }
 
   cnd_body
+}
+
+set_database_error_names <- function(cnd_body) {
+  # Respect names from `contextualize_database_error()`, otherwise ensure
+  # that the first is an "x" and the remainder are bulleted.
+  if (length(cnd_body) == 0) {
+    return(cnd_body)
+  }
+
+  if (is.null(names(cnd_body))) {
+    return(
+      set_names(cnd_body, nm = c("x", rep("*", length(cnd_body) - 1)))
+    )
+  }
+
+  set_names(
+    cnd_body,
+    c(
+      ifelse(names(cnd_body[1]) == "", "x", names(cnd_body[1])),
+      ifelse(names(cnd_body[-1]) == "", "*", names(cnd_body[-1]))
+    )
+  )
 }
 
 # check helpers for common odbc arguments --------------------------------------

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -27,6 +27,7 @@
       Error in `dbConnect()`:
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x Data source name not found and no default driver specified
+      * See ?odbcListDataSources (`?odbc::odbcListDataSources()`) to learn more.
       i From 'nanodbc/nanodbc.cpp:1150'.
 
 ---
@@ -56,6 +57,7 @@
       Error:
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x  Data source name not found and no default driver specified
+      * See ?odbcListDataSources (`?odbc::odbcListDataSources()`) to learn more.
       i From 'nanodbc/nanodbc.cpp:1135'.
 
 ---

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -27,7 +27,7 @@
       Error in `dbConnect()`:
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x Data source name not found and no default driver specified
-      * See `?odbc::odbcListDataSources()` to learn more.
+      i See `?odbc::odbcListDataSources()` to learn more.
       i From 'nanodbc/nanodbc.cpp:1150'.
 
 ---
@@ -57,7 +57,7 @@
       Error:
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x  Data source name not found and no default driver specified
-      * See `?odbc::odbcListDataSources()` to learn more.
+      i See `?odbc::odbcListDataSources()` to learn more.
       i From 'nanodbc/nanodbc.cpp:1135'.
 
 ---

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -27,7 +27,7 @@
       Error in `dbConnect()`:
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x Data source name not found and no default driver specified
-      * See ?odbcListDataSources (`?odbc::odbcListDataSources()`) to learn more.
+      * See `?odbc::odbcListDataSources()` to learn more.
       i From 'nanodbc/nanodbc.cpp:1150'.
 
 ---
@@ -57,7 +57,7 @@
       Error:
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x  Data source name not found and no default driver specified
-      * See ?odbcListDataSources (`?odbc::odbcListDataSources()`) to learn more.
+      * See `?odbc::odbcListDataSources()` to learn more.
       i From 'nanodbc/nanodbc.cpp:1135'.
 
 ---

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -83,6 +83,23 @@ test_that("parse_database_error() works with messages from the wild", {
   expect_snapshot(error = TRUE, rethrow_database_error(msg, call = NULL))
 })
 
+test_that("set_database_error_names() works (#840)", {
+  expect_equal(
+    set_database_error_names(c("unnamed", "vector")),
+    c(x = "unnamed", `*` = "vector")
+  )
+  expect_equal(set_database_error_names("unnamed scalar"), c(x = "unnamed scalar"))
+  expect_equal(
+    set_database_error_names(c("i" = "partially", "named")),
+    c(i = "partially", `*` = "named")
+  )
+  expect_equal(
+    set_database_error_names(c("partially", "i" = "named")),
+    c(x = "partially", i = "named")
+  )
+  expect_equal(set_database_error_names(c("i" = "named")), c(i = "named"))
+})
+
 test_that("set_odbcsysini() works (#791)", {
   skip_on_cran()
   skip_if(is_windows())


### PR DESCRIPTION
Rather than sending folks out to the "Data source name not found" google search results, we could refer to the revamped `odbcListDataSources` docs as a more beginner-accessible starting place to start debugging.

This is stepping a bit further into the territory of "patching" uninformative error messages from the driver manager and driver. Understood if we feel this is outside of the scope of the package.