### PR TITLE
Chore/get info convergence

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -82,13 +82,13 @@ bool has_result(connection_ptr const& p) {
 
 // [[Rcpp::export]]
 Rcpp::List connection_info(connection_ptr const& p) {
-  SQLUINTEGER getdata_ext;
-  SQLUINTEGER owner_usage;
+  std::uint64_t getdata_ext;
+  std::uint64_t owner_usage;
   try {
     getdata_ext =
-        (*p)->connection()->get_info<SQLUINTEGER>(SQL_GETDATA_EXTENSIONS);
+        (*p)->connection()->get_info<std::uint64_t>(SQL_GETDATA_EXTENSIONS);
     owner_usage =
-        (*p)->connection()->get_info<SQLUINTEGER>(SQL_SCHEMA_USAGE);
+        (*p)->connection()->get_info<std::uint64_t>(SQL_SCHEMA_USAGE);
   } catch (const nanodbc::database_error& c) {
     getdata_ext = 0;
     owner_usage = 0;

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -1283,8 +1283,9 @@ string_type connection::connection_impl::database_name() const
 }
 
 template string_type connection::get_info(short info_type) const;
-template SQLUSMALLINT connection::get_info(short info_type) const;
-template SQLUINTEGER connection::get_info(short info_type) const;
+template unsigned short connection::get_info(short info_type) const;
+template uint32_t connection::get_info(short info_type) const;
+template uint64_t connection::get_info(short info_type) const;
 
 } // namespace nanodbc
 

--- a/src/nanodbc/nanodbc.h
+++ b/src/nanodbc/nanodbc.h
@@ -321,6 +321,15 @@ struct timestamp
     std::int32_t fract; ///< Fractional seconds.
 };
 
+/// \brief A type trait for testing if a type is a std::basic_string compatible with the current
+/// nanodbc configuration
+template <typename T>
+using is_string = std::integral_constant<
+    bool,
+    std::is_same<typename std::decay<T>::type, std::string>::value ||
+        std::is_same<typename std::decay<T>::type, string_type>::value
+    >;
+
 /// \}
 
 /// \addtogroup mainc Main classes

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -39,7 +39,7 @@
       ! ODBC failed with error 00000 from [SQLite].
       x no such table: boopbopbopbeep (1)
       * <SQL> 'SELECT * FROM boopbopbopbeep'
-      i From 'nanodbc/nanodbc.cpp:1722'.
+      i From 'nanodbc/nanodbc.cpp:1726'.
 
 # rethrow_database_error() errors well when parse_database_error() fails
 


### PR DESCRIPTION
Hello:

Two commits in this PR:

* One is a backport of a [recent update](https://github.com/nanodbc/nanodbc/pull/418) in `nanodbc`, that made it possible to
* Realign our vendored library with upstream in the specification and usage `get_info_impl`.

Recall, we had made that departure in https://github.com/r-dbi/odbc/pull/677 in order to deal with the segfault in https://github.com/r-dbi/odbc/issues/624.  Had a chance to test that issue with this branch and encountered no problems.

Thanks!