### PR TITLE
dbConnect: clean up argument checks

### DIFF
--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -176,11 +176,11 @@ setMethod("dbConnect", "OdbcDriver",
       interruptible = getOption("odbc.interruptible", interactive()),
       .connection_string = NULL) {
     check_string(dsn, allow_null = TRUE)
-    check_string(timezone, allow_null = TRUE)
-    check_string(timezone_out, allow_null = TRUE)
-    check_string(encoding, allow_null = TRUE)
+    check_string(timezone)
+    check_string(timezone_out)
+    check_string(encoding)
     arg_match(bigint)
-    check_number_decimal(timeout, allow_null = TRUE, allow_na = TRUE)
+    check_number_decimal(timeout)
     check_string(driver, allow_null = TRUE)
     check_string(server, allow_null = TRUE)
     check_string(database, allow_null = TRUE)

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -87,8 +87,9 @@ setMethod("show", "OdbcDriver",
 #' @param bigint The R type that `SQL_BIGINT` types should be mapped to.
 #'   Default is [bit64::integer64], which allows the full range of 64 bit
 #'   integers.
-#' @param timeout Time in seconds to timeout the connection attempt. Setting a
-#'   timeout of `Inf` indicates no timeout. Defaults to 10 seconds.
+#' @param timeout Time in seconds to timeout the connection attempt. Setting an
+#'   `NA` timeout or a timeout of `Inf` indicates no timeout. Defaults to
+#'   10 seconds.
 #'
 #' @section Connection strings:
 #'
@@ -180,7 +181,7 @@ setMethod("dbConnect", "OdbcDriver",
     check_string(timezone_out)
     check_string(encoding)
     arg_match(bigint)
-    check_number_decimal(timeout)
+    check_number_decimal(timeout, allow_na = TRUE)
     check_string(driver, allow_null = TRUE)
     check_string(server, allow_null = TRUE)
     check_string(database, allow_null = TRUE)

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -87,9 +87,8 @@ setMethod("show", "OdbcDriver",
 #' @param bigint The R type that `SQL_BIGINT` types should be mapped to.
 #'   Default is [bit64::integer64], which allows the full range of 64 bit
 #'   integers.
-#' @param timeout Time in seconds to timeout the connection attempt. Setting an
-#'   `NA` timeout or a timeout of `Inf` indicates no timeout. Defaults to
-#'   10 seconds.
+#' @param timeout Time in seconds to timeout the connection attempt. Setting a
+#'   timeout of `Inf` or `NA` indicates no timeout. Defaults to 10 seconds.
 #'
 #' @section Connection strings:
 #'

--- a/R/odbc-connection.R
+++ b/R/odbc-connection.R
@@ -26,7 +26,7 @@ OdbcConnection <- function(
 
   bigint <- bigint_mappings()[match.arg(bigint, names(bigint_mappings()))]
 
-  if (is.infinite(timeout)) {
+  if (is.infinite(timeout) || is.na(timeout)) {
     timeout <- 0
   }
 

--- a/man/dbConnect-OdbcDriver-method.Rd
+++ b/man/dbConnect-OdbcDriver-method.Rd
@@ -64,7 +64,7 @@ Default is \link[bit64:bit64-package]{bit64::integer64}, which allows the full r
 integers.}
 
 \item{timeout}{Time in seconds to timeout the connection attempt. Setting a
-timeout of \code{Inf} indicates no timeout. Defaults to 10 seconds.}
+timeout of \code{Inf} or \code{NA} indicates no timeout. Defaults to 10 seconds.}
 
 \item{driver}{The ODBC driver name or a path to a driver. For currently
 available options, see the \code{name} column of \code{\link[=odbcListDrivers]{odbcListDrivers()}} output.}


### PR DESCRIPTION
Closes https://github.com/r-dbi/odbc/issues/848

* See issue for examples of how `NULL`s for specific arguments in `dbConnect` are handled prior to this patch.
* With this patch:
```
┃  > dbConnect(odbc::odbc(), dsn = "mssql_oem_db", encoding = NULL )
┃                                                  Error in `.local()`:
┃  ! `encoding` must be a single string, not `NULL`.
┃  Run `rlang::last_trace()` to see where the error occurred.
┃  > dbConnect(odbc::odbc(), dsn = "mssql_oem_db", timezone = NULL )
┃                                                  Error in `.local()`:
┃  ! `timezone` must be a single string, not `NULL`.
┃  Run `rlang::last_trace()` to see where the error occurred.
┃  > dbConnect(odbc::odbc(), dsn = "mssql_oem_db", timezone_out = NULL )
┃                                                  Error in `.local()`:
┃  ! `timezone_out` must be a single string, not `NULL`.
┃  Run `rlang::last_trace()` to see where the error occurred.
┃  > dbConnect(odbc::odbc(), dsn = "mssql_oem_db", timeout = NULL )
┃                                                  Error in `.local()`:
┃  ! `timeout` must be a number, not `NULL`.
┃  Run `rlang::last_trace()` to see where the error occurred.
```

~Also disallowed `NA` for `timeout`, as it's not clear from the documentation how that would be handled ( we allow `Inf` to mean "no timeout".  IMO that's intuitive enough. )~ Also documented the usage of `NA` for the `timeout` argument.  No change in prior behavior.

Thanks!