### PR TITLE
Add support for default application value within `snowflake()`

### DIFF
--- a/R/driver-snowflake.R
+++ b/R/driver-snowflake.R
@@ -193,11 +193,11 @@ snowflake_args <- function(account = Sys.getenv("SNOWFLAKE_ACCOUNT"),
 
   # Set application value and respect the Snowflake Partner environment variable, if present.
   if (is.null(all$application)) {
-    all$application <- ifelse(
-      nchar(Sys.getenv("SF_PARTNER")) != 0,
-      all$application <- Sys.getenv("SF_PARTNER"),
-      paste0("r-odbc/", packageVersion("odbc"))
-    )
+    if (nchar(Sys.getenv("SF_PARTNER")) != 0 ){
+      all$application <- Sys.getenv("SF_PARTNER")
+    } else {
+      all$application <- paste0("r-odbc/", packageVersion("odbc"))
+    }
   }
 
   arg_names <- tolower(names(all))

--- a/R/driver-snowflake.R
+++ b/R/driver-snowflake.R
@@ -191,9 +191,13 @@ snowflake_args <- function(account = Sys.getenv("SNOWFLAKE_ACCOUNT"),
   auth <- snowflake_auth_args(account, ...)
   all <- utils::modifyList(c(args, auth), list(...))
 
-  # Respect the Snowflake Partner environment variable, if present.
-  if (is.null(all$application) && nchar(Sys.getenv("SF_PARTNER")) != 0) {
-    all$application <- Sys.getenv("SF_PARTNER")
+  # Set application value and respect the Snowflake Partner environment variable, if present.
+  if (is.null(all$application)) {
+    all$application <- ifelse(
+      nchar(Sys.getenv("SF_PARTNER")) != 0,
+      all$application <- Sys.getenv("SF_PARTNER"),
+      paste0("r-odbc/", packageVersion("odbc"))
+    )
   }
 
   arg_names <- tolower(names(all))


### PR DESCRIPTION
This aligns the behavior of `snowflake()` with `databricks()` so that in each case the user identifier is set to `r-odbc/{version}` by default.