### PR TITLE
tests: prune skips

### DIFF
--- a/tests/testthat/test-driver-oracle.R
+++ b/tests/testthat/test-driver-oracle.R
@@ -40,7 +40,6 @@ test_that("Oracle", {
     "quote_identifier.*",
     "read_table.*",
     "create_table.*",
-    "create_temporary_table",
     "create_table_visible.*",
     "create_roundtrip_quotes",
     "append_roundtrip_quotes_column_names",

--- a/tests/testthat/test-driver-postgres.R
+++ b/tests/testthat/test-driver-postgres.R
@@ -57,7 +57,6 @@ test_that("PostgreSQL", {
     "unquote_identifier_vectorized", # TODO
     "create_table_overwrite", # TODO
     "create_table_error", # TODO
-    "create_temporary_table", # TODO
     "append_table_.*", # TODO
     "append_roundtrip_.*", # TODO
     "append_table_.*", # TODO

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -54,7 +54,6 @@ test_that("SQLServer", {
     "quote_literal_na_is_null",
     "quote_literal_na_is_null",
     "create_table_error",
-    "create_temporary_table",
     "roundtrip_64_bit_roundtrip",
     "write_table_row_names_default",
     "list_fields_wrong_table",

--- a/tests/testthat/test-driver-sqlite.R
+++ b/tests/testthat/test-driver-sqlite.R
@@ -72,7 +72,6 @@ test_that("SQLite", {
     "read_table_row_names_na_missing", # TODO
     "create_table_overwrite", # TODO
     "create_table_error", # TODO
-    "create_temporary_table", # TODO
     "create_table_visible_in_other_connection", # TODO
     "append_table_missing", # TODO
     "append_table_append_incompatible", # TODO


### PR DESCRIPTION
I am seeing this in our pipelines:

```
────────────────────────────────────────────────────────────────────────────────
Warning ('test-driver-sqlite.R:50:3'): SQLite
Unused skip expressions: create_temporary_table
Backtrace:
    ▆
 1. └─DBItest::test_sql(...) at test-driver-sqlite.R:50:3
 2.   └─DBItest:::run_tests(ctx, spec_sql, skip, run_only, test_suite) at DBItest/R/test-sql.R:17:3
 3.     └─DBItest:::get_skip_names(skip) at DBItest/R/run.R:29:3
────────────────────────────────────────────────────────────────────────────────
```

Looks like perhaps this test was removed from the testing suite.