### PR TITLE
ci: keep up with mysql driver updates

### DIFF
--- a/.github/workflows/db-windows.yml
+++ b/.github/workflows/db-windows.yml
@@ -56,7 +56,7 @@ jobs:
         if: matrix.database == 'MySQL'
         run: |
           choco install mysql.odbc
-          echo "ODBC_CS_MYSQL=Driver={MySQL ODBC 9.1 ANSI Driver};Server=127.0.0.1;Database=test;User=root;Password=" >> $env:GITHUB_ENV
+          echo "ODBC_CS_MYSQL=Driver={$(Get-OdbcDriver -Platform 64-bit | Select-Object -ExpandProperty Name | Select-String -Pattern 'ANSI')};Server=127.0.0.1;Database=test;User=root;Password=" >> $env:GITHUB_ENV
 
       - name: Install PostgreSQL
         if: matrix.database == 'PostgreSQL'

--- a/.github/workflows/db-windows.yml
+++ b/.github/workflows/db-windows.yml
@@ -56,7 +56,7 @@ jobs:
         if: matrix.database == 'MySQL'
         run: |
           choco install mysql.odbc
-          echo "ODBC_CS_MYSQL=Driver={MySQL ODBC 9.0 ANSI Driver};Server=127.0.0.1;Database=test;User=root;Password=" >> $env:GITHUB_ENV
+          echo "ODBC_CS_MYSQL=Driver={MySQL ODBC 9.1 ANSI Driver};Server=127.0.0.1;Database=test;User=root;Password=" >> $env:GITHUB_ENV
 
       - name: Install PostgreSQL
         if: matrix.database == 'PostgreSQL'


### PR DESCRIPTION
We should probably think about how we can avoid needing to do this in the future.

Couple of options:
* We can ask `choco` to install a fixed version, I believe; or
* Extract the driver version programmatically and inject it into the connection string.

First one is easy; the second would allow us to move forward with the driver versions without upkeep.