### PR TITLE
correct erroring fn names

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -316,9 +316,9 @@ configure_simba <- function(driver_config,
 
   simba_config <- driver_config$path
   if (length(simba_config) == 0) {
-    func <- cli::warn
+    func <- cli::cli_warn
     if (action == "modify") {
-      fun <- cli::abort
+      fun <- cli::cli_abort
     }
     func(
       c(i = "Please install the needed driver from {driver_config$url}"),


### PR DESCRIPTION
Addresses an R CMD check warning leftover from #857 that we missed.