### PR TITLE
Add `/usr/lib/x86_64-linux-gnu` to the list of common `libodbcinst` dirs

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -343,6 +343,7 @@ locate_install_unixodbc <- function() {
     "/usr/local",
     "/lib",
     "/usr/local/lib",
+    "/usr/lib/x86_64-linux-gnu",
     "/opt/homebrew/lib",
     "/opt/homebrew/opt/unixodbc/lib"
   )


### PR DESCRIPTION
This fixes `locate_install_unixodbc()` on fresh Ubuntu 22.04 installs, which don't otherwise include `pkg-confg` or use the existing common paths.

Fixes #880.