### PR TITLE
Fixup/sqlserver datetime2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # odbc (development version)
 
+* SQL Server: Writing to DATETIME2 targets respects precision (#793).
 
 * snowflake: Runtime driver configuration checks on `MacOS` (#857).
 

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -1907,7 +1907,7 @@ public:
         describe_parameters(param_index);
         const SQLSMALLINT& param_type = param_descr_data_.at(param_index).type_;
         NANODBC_ASSERT(param_type < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
-        return static_cast<unsigned long>(param_type);
+        return static_cast<short>(param_type);
     }
 
     static SQLSMALLINT param_type_from_direction(param_direction direction)

--- a/src/nanodbc/nanodbc.h
+++ b/src/nanodbc/nanodbc.h
@@ -697,6 +697,12 @@ public:
     /// \brief Returns parameter size for indicated parameter placeholder in a prepared statement.
     unsigned long parameter_size(short param_index) const;
 
+    /// \brief Returns parameter scale for indicated parameter placeholder in a prepared statement.
+    short parameter_scale(short param_index) const;
+
+    /// \brief Returns parameter type for indicated parameter placeholder in a prepared statement.
+    short parameter_type(short param_index) const;
+
     /// \addtogroup binding Binding parameters
     /// \brief These functions are used to bind values to ODBC parameters.
     ///

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -135,7 +135,7 @@ private:
       size_t start,
       size_t size);
 
-  nanodbc::timestamp as_timestamp(double value);
+  nanodbc::timestamp as_timestamp(double value, unsigned long long factor, unsigned long long pad);
 
   nanodbc::date as_date(double value);
 

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -371,5 +371,5 @@ test_that("DATETIME2 precision (#790)", {
   tbl <- local_table(con, "test_datetime2_precision", df,
     field.types = list("dtm" = "DATETIME", "dtm2" = "DATETIME2(6)"))
   res <- DBI::dbReadTable(con, tbl)
-  expect_equal(as.POSIXlt(df[[2]])$sec, as.POSIXlt(res[[2]])$sec)
+  expect_equal(as.POSIXlt(df[[2]])$sec, as.POSIXlt(res[[2]])$sec, tolerance = 1E-7)
 })


### PR DESCRIPTION
Closes https://github.com/r-dbi/odbc/issues/793

This is a long standing issue where we were forcing a precision of 3 for all DATETIME types despite some ( for example DATETIME2 ) having potentially greater precision.

Requires a backport from nanodbc.