### PR TITLE
sql server: fix writing to tmp tables with FreeTDS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* SQL Server: Fix data truncation when writing to temp tables with
+  `FreeTDS` (#866).
+
 * Addressed issue where error messages rethrown from some drivers would be
   garbled when the raw error message contained curly brackets 
   (#859 by @simonpcouch).

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -249,3 +249,15 @@ setMethod("odbcConnectionColumns_", c("Microsoft SQL Server", "character"),
     )
   }
 )
+
+#' @description
+#' ## `odbcConnectionColumns_()`
+#'
+#' Copied over from odbc-connection to avoid S4 dispatch NOTEs.
+#' @rdname SQLServer
+#' @usage NULL
+setMethod("odbcConnectionColumns_", c("Microsoft SQL Server", "SQL"),
+  function(conn, name, ...) {
+    odbcConnectionColumns_(conn, dbUnquoteIdentifier(conn, name)[[1]], ...)
+  }
+)

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -214,3 +214,38 @@ setMethod("odbcDataType", "Microsoft SQL Server",
     )
   }
 )
+
+#' @description
+#' ## `odbcConnectionColumns_()`
+#'
+#' If temp table, query the database for the
+#' actual table name.
+#' @rdname SQLServer
+#' @usage NULL
+setMethod("odbcConnectionColumns_", c("Microsoft SQL Server", "character"),
+  function(conn,
+           name,
+           ...,
+           catalog_name = NULL,
+           schema_name = NULL,
+           column_name = NULL,
+           exact = FALSE) {
+    if (isTempTable(conn, name, catalog_name, schema_name, column_name, exact)) {
+      catalog_name <- "tempdb"
+      schema_name <- "dbo"
+      query <- paste0("SELECT name FROM tempdb.sys.tables WHERE ",
+        "object_id = OBJECT_ID('tempdb..", name, "')")
+      name <- dbGetQuery(conn, query)[[1]]
+    }
+
+    callNextMethod(
+      conn = conn,
+      name = name,
+      ...,
+      catalog_name = catalog_name,
+      schema_name = schema_name,
+      column_name = column_name,
+      exact = exact
+    )
+  }
+)


### PR DESCRIPTION
Hi:

This fixes an issue seen when writing to temp tables in SQL Server when using FreeTDS:

```
val <- paste(rep(paste(LETTERS, collapse = ""), 100), collapse = "")
> nchar(val)
[1] 2600
dbWriteTable(conn, "#test_freetds_tmp_write", data.frame(col = val))
res <- DBI::dbReadTable(conn, "#test_freetds_tmp_write")
> nchar(res[[1]])
[1] 255
---------------------------
> conn@info$drivername
[1] "libtdsodbc.so"
> conn@info$driver.version
[1] "01.01.9999"
```

It introduces an additional query or two when writing ( to temp tables ), but I think the cost is sufficiently low that I am not too concerned about it yet.  Besides, without this patch, `odbcConnectionColumns` is genuinly broken for temp tables / doesn't work for any driver; it's just that the OEM driver can manage the write despite us not being able to discern the parameter types.