### PR TITLE
sql server: Roundtrip of hms data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # odbc (development version)
 
+* SQL Server: Fix roundtrip of `hms` data.
+
 * SQL Server: Fix data truncation when writing to temp tables with
   `FreeTDS` (#866).
 

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -5,6 +5,9 @@
 #include <chrono>
 #include <memory>
 
+#ifndef SQL_SS_TIME2
+#define SQL_SS_TIME2 (-154)
+#endif
 namespace odbc {
 
 using odbc::utils::run_interruptible;
@@ -691,6 +694,7 @@ std::vector<r_type> odbc_result::column_types(nanodbc::result const& r) {
       break;
     // Time
     case SQL_TIME:
+    case SQL_SS_TIME2:
     case SQL_TYPE_TIME:
       types.push_back(odbc::time_t);
       break;

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -373,3 +373,7 @@ test_that("DATETIME2 precision (#790)", {
   res <- DBI::dbReadTable(con, tbl)
   expect_equal(as.POSIXlt(df[[2]])$sec, as.POSIXlt(res[[2]])$sec, tolerance = 1E-7)
 })
+
+test_that("package:odbc roundtrip test", {
+  test_roundtrip(test_con("SQLSERVER"))
+})


### PR DESCRIPTION
Last failing column from the `test_roundtrip` suite for SQL Server.