### PR TITLE
sql server: connection columns: temp tables: custom logic only if exact

### DIFF
--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -230,7 +230,8 @@ setMethod("odbcConnectionColumns_", c("Microsoft SQL Server", "character"),
            schema_name = NULL,
            column_name = NULL,
            exact = FALSE) {
-    if (isTempTable(conn, name, catalog_name, schema_name, column_name, exact)) {
+    if (exact &&
+      isTempTable(conn, name, catalog_name, schema_name, column_name, exact)) {
       catalog_name <- "tempdb"
       schema_name <- "dbo"
       query <- paste0("SELECT name FROM tempdb.sys.tables WHERE ",


### PR DESCRIPTION
Hi Team:

In virtually all cases we care about we call `odbcConnectionColumns_` with `exact = TRUE`.  Just covering our bases here and making sure the custom logic ( which looks for the temp table name exactly ) is only called when the `exact` parameter is set to `TRUE`. 

Going back and forth here about writing a unit test.  For one we are deprecating this method for external usage ( where the user might set exact to `FALSE` ).   I also feel like the logic here is obvious enough that we don't need one ( famous last words! )

Thank you!