### PR TITLE
Ensure odbc locates SQL Server drivers on macOS running on Apple Silicon. Addresses #892

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* Enable automatic discovery of SQL Server drivers installed with homebrew 
+  on ARM macOS (@stevecondylios, #893).
+
 * SQL Server: Fix roundtrip of `hms` data.
 
 * SQL Server: Fix data truncation when writing to temp tables with

--- a/R/utils.R
+++ b/R/utils.R
@@ -360,6 +360,7 @@ locate_install_unixodbc <- function() {
     "/usr/local/lib",
     "/usr/lib/x86_64-linux-gnu",
     "/opt/homebrew/lib",
+    "/opt/homebrew/etc",
     "/opt/homebrew/opt/unixodbc/lib"
   )
 


### PR DESCRIPTION
This updates `common_dirs` in `locate_install_unixodbc()` to ensure odbc is able to find database drivers and set the `ODBCSYSINI` environment variable correctly. It is based on the path to which [homebrew](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver16#microsoft-odbc-18) installs SQL Server drivers on macOS running on Apple Silicon.

[Homebrew](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver16#microsoft-odbc-18) is the installation method recommended by Microsoft.

Before change:

```
odbc::odbcListDrivers()
# [1] name      attribute value    
# <0 rows> (or 0-length row.names)

```

After change (drivers automatically located by odbc):

```
odbc::odbcListDrivers()
#                            name   attribute                                   value
# 1 ODBC Driver 18 for SQL Server Description Microsoft ODBC Driver 18 for SQL Server
# 2 ODBC Driver 18 for SQL Server      Driver /opt/homebrew/lib/libmsodbcsql.18.dylib
# 3 ODBC Driver 18 for SQL Server  UsageCount                                       1


```