### PR TITLE
nanodbc: backport TVP patches

### DIFF
--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -28,7 +28,7 @@
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x Data source name not found and no default driver specified
       i See `?odbc::odbcListDataSources()` to learn more.
-      i From 'nanodbc/nanodbc.cpp:1159'.
+      i From 'nanodbc/nanodbc.cpp:1184'.
 
 ---
 
@@ -39,7 +39,7 @@
       ! ODBC failed with error 00000 from [SQLite].
       x no such table: boopbopbopbeep (1)
       * <SQL> 'SELECT * FROM boopbopbopbeep'
-      i From 'nanodbc/nanodbc.cpp:1735'.
+      i From 'nanodbc/nanodbc.cpp:1802'.
 
 # rethrow_database_error() errors well when parse_database_error() fails
 


### PR DESCRIPTION
Hi:

This catches up our vendored nanodbc lib to upstream in terms of TVP functionality.  Not part of this PR:

* Upstream TVP functionality that [is in review](https://github.com/nanodbc/nanodbc/pull/426).
* Updates to 'odbc' API to take advantage of this feature. 

On the last two I will prepare a new PR; the diff on this one alone ended up being large enough that I thought breaking it out might make sense in terms of being able to better attribute any changes in existing behavior ( hopefully none! ).

Compare upstream: https://github.com/nanodbc/nanodbc/pull/259