### PR TITLE
utils: locate_unixodbc: account for statically built unixodbc (CRAN)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -361,7 +361,9 @@ locate_install_unixodbc <- function() {
     "/usr/lib/x86_64-linux-gnu",
     "/opt/homebrew/lib",
     "/opt/homebrew/etc",
-    "/opt/homebrew/opt/unixodbc/lib"
+    "/opt/homebrew/opt/unixodbc/lib",
+    "/opt/R/arm64/lib",
+    "/opt/R/x86_64/lib"
   )
 
   list.files(
@@ -375,7 +377,12 @@ system_safely <- function(x) {
   tryCatch(
     {
       unixodbc_prefix <- system(x, intern = TRUE, ignore.stderr = TRUE)
-      return(paste0(unixodbc_prefix, "/", libodbcinst_filename()))
+      candidates <- list.files(unixodbc_prefix,
+        pattern = libodbcinst_filename(), full.names = TRUE)
+      if (!length(candidates)) {
+        stop("Unable to locate unixodbc using odbc_config")
+      }
+      return(candidates[1])
     },
     error = function(e) {},
     warning = function(w) {}
@@ -383,11 +390,13 @@ system_safely <- function(x) {
   character()
 }
 
+# Returns a pattern to be used with
+# list.files( ..., pattern = ... ).
 libodbcinst_filename <- function() {
   if (is_macos()) {
-    "libodbcinst.dylib"
+    "libodbcinst.dylib|libodbcinst.a"
   } else {
-    "libodbcinst.so"
+    "libodbcinst.so|libodbcinst.a"
   }
 }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -178,7 +178,7 @@ test_that("locate_install_unixodbc() returns reasonable values", {
   res <- locate_install_unixodbc()
 
   expect_true(file.exists(res[1]))
-  expect_true(grepl("\\.dylib", res[1]))
+  expect_true(grepl("(\\.dylib|\\.a)$", res[1]))
 })
 
 test_that("databricks() errors informatively when spark ini isn't writeable", {


### PR DESCRIPTION
Attempt to fix errors reported on CRAN ( where the build machine is using a statically buit `unixodbc` ).
Used a simple "stop" rather than something with better formatting since that error does not propagate to the user.