### PR TITLE
nanodbc:bugfix: describe_data: if unsuccesful cleanup

### DIFF
--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -2132,7 +2132,10 @@ public:
             &param_descr_data_[param_index].scale_,
             &nullable);
         if (!success(rc))
+        {
+            param_descr_data_.erase(param_index);
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
+        }
     }
 
     void describe_parameters(


### PR DESCRIPTION
Related to https://github.com/r-dbi/odbc/issues/906

In particular: see https://github.com/r-dbi/odbc/issues/906#issuecomment-2764771285 for more detailed analysis.