### PR TITLE
odbcConnectionColumns_: s4 dispatch: correctly propagate `exact` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* SQL Server: Fix issues with argument propagation in bespoke
+  S4 methods (#906).
+
 # odbc 1.6.1
 
 * odbc will now automatically find statically built installations of

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -258,7 +258,7 @@ setMethod("odbcConnectionColumns_", c("Microsoft SQL Server", "character"),
 #' @rdname SQLServer
 #' @usage NULL
 setMethod("odbcConnectionColumns_", c("Microsoft SQL Server", "SQL"),
-  function(conn, name, ...) {
-    odbcConnectionColumns_(conn, dbUnquoteIdentifier(conn, name)[[1]], ...)
+  function(conn, name, ..., exact = FALSE) {
+    odbcConnectionColumns_(conn, dbUnquoteIdentifier(conn, name)[[1]], ..., exact = exact)
   }
 )

--- a/R/odbc-connection.R
+++ b/R/odbc-connection.R
@@ -335,8 +335,8 @@ setMethod("odbcConnectionColumns_", c("OdbcConnection", "character"),
 )
 
 setMethod("odbcConnectionColumns_", c("OdbcConnection", "SQL"),
-  function(conn, name, ...) {
-    odbcConnectionColumns_(conn, dbUnquoteIdentifier(conn, name)[[1]], ...)
+  function(conn, name, ..., exact = FALSE) {
+    odbcConnectionColumns_(conn, dbUnquoteIdentifier(conn, name)[[1]], ..., exact = exact)
   }
 )
 


### PR DESCRIPTION
Related to https://github.com/r-dbi/odbc/issues/906

In particular see: https://github.com/r-dbi/odbc/issues/906#issuecomment-2764771285

Double check my S4 dispatch work here - the "exact" argument was being caught by the ellipsis as the S4 dispatch called the "SQL" method first and moved on to the "character" next.