### PR TITLE
Add support for SQL Server DATETIMEOFFSET data type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # odbc (development version)
 
+* SQL Server: Support for `DATETIMEOFFSET` data type (#918). 
+
 * SQL Server: Fix issues with argument propagation in bespoke
   S4 methods (#906).
 

--- a/R/dbi-driver.R
+++ b/R/dbi-driver.R
@@ -42,6 +42,11 @@ setMethod("show", "OdbcDriver",
 #'   timezone that is _not_ 'UTC'. If the database is in your local timezone,
 #'   set this argument to [Sys.timezone()]. See [OlsonNames()] for a complete
 #'   list of available time zones on your system.
+#'   Note, if the datatype itself carries timezone information, as is the case,
+#'   for example, with SQL Server::DATETIMEOFFSET, `package:odbc` will make
+#'   an effort to respect the timezone declared therein.  In those cases,
+#'   this parameter is not used - the timezone that is part of the datatype
+#'   takes precedence.
 #' @param timezone_out The time zone returned to R. If you want to display
 #'   datetime values in the local timezone, set to [Sys.timezone()].
 #' @param encoding The text encoding used on the Database. If the database is

--- a/src/cctz/Makefile
+++ b/src/cctz/Makefile
@@ -47,6 +47,7 @@ CCTZ_HDRS =			\
 	time_zone.h
 
 CCTZ_OBJS =			\
+	time_zone_fixed.o \
 	time_zone_format.o	\
 	time_zone_if.o		\
 	time_zone_impl.o	\

--- a/src/cctz/include/time_zone.h
+++ b/src/cctz/include/time_zone.h
@@ -32,6 +32,7 @@ template <typename D>
 using time_point = std::chrono::time_point<std::chrono::system_clock, D>;
 using sys_seconds = std::chrono::duration<std::chrono::system_clock::rep,
                                           std::chrono::seconds::period>;
+using seconds = sys_seconds;
 
 // cctz::time_zone is an opaque, small, value-type class representing a
 // geo-political region within which particular rules are used for mapping
@@ -146,6 +147,12 @@ bool load_time_zone(const std::string& name, time_zone* tz);
 
 // Returns a time_zone representing UTC. Cannot fail.
 time_zone utc_time_zone();
+
+// Returns a time zone that is a fixed offset (seconds east) from UTC.
+// Note: If the absolute value of the offset is greater than 24 hours
+// you'll get UTC (i.e., zero offset) instead.
+time_zone fixed_time_zone(const seconds& offset);
+bool fixed_time_zone(const seconds& offset, time_zone* tz);
 
 // Returns a time zone representing the local time zone. Falls back to UTC.
 time_zone local_time_zone();

--- a/src/cctz/src/time_zone_fixed.cc
+++ b/src/cctz/src/time_zone_fixed.cc
@@ -125,8 +125,11 @@ std::string FixedOffsetToName(const seconds& offset) {
     ep = Format02d(ep, offset_seconds, false);
   }
   *ep++ = '\0';
-  // package:odbc: Less strict assert
-  assert(ep - buf <= (long int)sizeof(buf));
+  // package:odbc: Less strict
+  // package:odbc: throw rather than assert
+  if (ep - buf > (long int)sizeof(buf)) {
+    throw std::runtime_error("Unexpected buffer overflow");
+  }
   return buf;
 }
 

--- a/src/cctz/src/time_zone_fixed.cc
+++ b/src/cctz/src/time_zone_fixed.cc
@@ -1,0 +1,150 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#include "time_zone_fixed.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <string>
+
+namespace cctz {
+
+namespace {
+
+// The prefix used for the internal names of fixed-offset zones.
+// package:odbc changed from "Fixed/UTC"
+const char kFixedZonePrefix[] = "Etc/GMT";
+
+const char kDigits[] = "0123456789";
+
+char* Format02d(char* p, int v, bool singleDigitIfPossible) {
+  // package::odbc
+  // Only append leading / decimal place
+  // digit if nonzero
+  auto decDigit = kDigits[(v / 10) % 10];
+  if ( !singleDigitIfPossible || decDigit != '0' ) {
+    *p++ = decDigit;
+  }
+  *p++ = kDigits[v % 10];
+  return p;
+}
+
+int Parse02d(const char* p) {
+  if (const char* ap = std::strchr(kDigits, *p)) {
+    int v = static_cast<int>(ap - kDigits);
+    if (const char* bp = std::strchr(kDigits, *++p)) {
+      return (v * 10) + static_cast<int>(bp - kDigits);
+    }
+  }
+  return -1;
+}
+
+}  // namespace
+
+bool FixedOffsetFromName(const std::string& name, seconds* offset) {
+  if (name == "UTC" || name == "UTC0") {
+    *offset = seconds::zero();
+    return true;
+  }
+
+  const std::size_t prefix_len = sizeof(kFixedZonePrefix) - 1;
+  const char* const ep = kFixedZonePrefix + prefix_len;
+  if (name.size() != prefix_len + 9)  // <prefix>+99:99:99
+    return false;
+  if (!std::equal(kFixedZonePrefix, ep, name.begin()))
+    return false;
+  const char* np = name.data() + prefix_len;
+  if (np[0] != '+' && np[0] != '-')
+    return false;
+  if (np[3] != ':' || np[6] != ':')  // see note below about large offsets
+    return false;
+
+  int hours = Parse02d(np + 1);
+  if (hours == -1) return false;
+  int mins = Parse02d(np + 4);
+  if (mins == -1) return false;
+  int secs = Parse02d(np + 7);
+  if (secs == -1) return false;
+
+  secs += ((hours * 60) + mins) * 60;
+  if (secs > 24 * 60 * 60) return false;  // outside supported offset range
+  *offset = seconds(secs * (np[0] == '-' ? -1 : 1));  // "-" means west
+  return true;
+}
+
+std::string FixedOffsetToName(const seconds& offset) {
+  if (offset == seconds::zero()) return "UTC";
+  if (offset < std::chrono::hours(-24) || offset > std::chrono::hours(24)) {
+    // We don't support fixed-offset zones more than 24 hours
+    // away from UTC to avoid complications in rendering such
+    // offsets and to (somewhat) limit the total number of zones.
+    return "UTC";
+  }
+  int offset_seconds = static_cast<int>(offset.count());
+  const char sign = (offset_seconds < 0 ? '-' : '+');
+  int offset_minutes = offset_seconds / 60;
+  offset_seconds %= 60;
+  if (sign == '-') {
+    if (offset_seconds > 0) {
+      offset_seconds -= 60;
+      offset_minutes += 1;
+    }
+    offset_seconds = -offset_seconds;
+    offset_minutes = -offset_minutes;
+  }
+  int offset_hours = offset_minutes / 60;
+  offset_minutes %= 60;
+  const std::size_t prefix_len = sizeof(kFixedZonePrefix) - 1;
+  char buf[prefix_len + sizeof("-24:00:00")];
+  char* ep = std::copy_n(kFixedZonePrefix, prefix_len, buf);
+  *ep++ = sign;
+  // package:odbc: When appending hours
+  // offset, reduce to single digit if possible
+  ep = Format02d(ep, offset_hours, true);
+  // package:odbc: Append min/sec offset
+  // only if nonzero
+  if (offset_minutes != 0) {
+    *ep++ = ':';
+    ep = Format02d(ep, offset_minutes, false);
+  }
+  if (offset_seconds != 0) {
+    *ep++ = ':';
+    ep = Format02d(ep, offset_seconds, false);
+  }
+  *ep++ = '\0';
+  // package:odbc: Less strict assert
+  assert(ep - buf <= (long int)sizeof(buf));
+  return buf;
+}
+
+std::string FixedOffsetToAbbr(const seconds& offset) {
+  std::string abbr = FixedOffsetToName(offset);
+  const std::size_t prefix_len = sizeof(kFixedZonePrefix) - 1;
+  if (abbr.size() == prefix_len + 9) {         // <prefix>+99:99:99
+    abbr.erase(0, prefix_len);                 // +99:99:99
+    abbr.erase(6, 1);                          // +99:9999
+    abbr.erase(3, 1);                          // +999999
+    if (abbr[5] == '0' && abbr[6] == '0') {    // +999900
+      abbr.erase(5, 2);                        // +9999
+      if (abbr[3] == '0' && abbr[4] == '0') {  // +9900
+        abbr.erase(3, 2);                      // +99
+      }
+    }
+  }
+  return abbr;
+}
+
+}  // namespace cctz

--- a/src/cctz/src/time_zone_fixed.h
+++ b/src/cctz/src/time_zone_fixed.h
@@ -1,0 +1,45 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#ifndef CCTZ_TIME_ZONE_FIXED_H_
+#define CCTZ_TIME_ZONE_FIXED_H_
+
+#include <string>
+
+#include "time_zone.h"
+
+namespace cctz {
+
+// Helper functions for dealing with the names and abbreviations
+// of time zones that are a fixed offset (seconds east) from UTC.
+// FixedOffsetFromName() extracts the offset from a valid fixed-offset
+// name, while FixedOffsetToName() and FixedOffsetToAbbr() generate
+// the canonical zone name and abbreviation respectively for the given
+// offset.
+//
+// A fixed-offset name looks like "Fixed/UTC<+-><hours>:<mins>:<secs>".
+// Its abbreviation is of the form "UTC(<+->H?H(MM(SS)?)?)?" where the
+// optional pieces are omitted when their values are zero.  (Note that
+// the sign is the opposite of that used in a POSIX TZ specification.)
+//
+// Note: FixedOffsetFromName() fails on syntax errors or when the parsed
+// offset exceeds 24 hours.  FixedOffsetToName() and FixedOffsetToAbbr()
+// both produce "UTC" when the argument offset exceeds 24 hours.
+bool FixedOffsetFromName(const std::string& name, seconds* offset);
+std::string FixedOffsetToName(const seconds& offset);
+std::string FixedOffsetToAbbr(const seconds& offset);
+
+}  // namespace cctz
+
+#endif  // CCTZ_TIME_ZONE_FIXED_H_

--- a/src/cctz/src/time_zone_lookup.cc
+++ b/src/cctz/src/time_zone_lookup.cc
@@ -16,6 +16,7 @@
 
 #include <cstdlib>
 
+#include "time_zone_fixed.h"
 #include "time_zone_impl.h"
 
 namespace cctz {
@@ -23,6 +24,16 @@ namespace cctz {
 time_zone utc_time_zone() {
   time_zone tz;
   load_time_zone("UTC", &tz);
+  return tz;
+}
+
+bool fixed_time_zone(const seconds& offset, time_zone* tz) {
+  return load_time_zone(FixedOffsetToName(offset), tz);
+}
+
+time_zone fixed_time_zone(const seconds& offset) {
+  time_zone tz;
+  load_time_zone(FixedOffsetToName(offset), &tz);
   return tz;
 }
 

--- a/src/nanodbc/nanodbc.h
+++ b/src/nanodbc/nanodbc.h
@@ -321,6 +321,14 @@ struct timestamp
     std::int32_t fract; ///< Fractional seconds.
 };
 
+/// \brief A type for representing timestamp data.
+struct timestampoffset
+{
+    timestamp    stamp;
+    std::int16_t offset_hour;     ///< Whole hour part of time zone offset
+    std::int16_t offset_minute;   ///< Minutes part of time zome offset
+};
+
 /// \brief A type trait for testing if a type is a std::basic_string compatible with the current
 /// nanodbc configuration
 template <typename T>

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -8,6 +8,9 @@
 #ifndef SQL_SS_TIME2
 #define SQL_SS_TIME2 (-154)
 #endif
+#ifndef SQL_SS_TIMESTAMPOFFSET
+#define SQL_SS_TIMESTAMPOFFSET (-155)
+#endif
 namespace odbc {
 
 using odbc::utils::run_interruptible;
@@ -504,6 +507,42 @@ std::vector<std::string> odbc_result::column_names(nanodbc::result const& r) {
   return names;
 }
 
+double odbc_result::as_double(nanodbc::timestampoffset const& tso) {
+  using namespace cctz;
+  if (tso.offset_hour == 0 && tso.offset_minute == 0) {
+    return as_double(tso.stamp);
+  }
+  const sys_seconds offset(tso.offset_hour * 3600 + tso.offset_minute * 60);
+
+  // Make sure we can load timezone
+  // Capture any error that we can raise
+  // to [R] more gracefully.
+  //
+  // Note, when the TZ file can't be located on the FS,
+  // `fixed_time_zone` will return false (and fallback to utc).
+  // As we want to throw this warning ONCE, and not on *every*
+  // failed row value, we test to see whether `cctz` has thrown
+  // an error.  There, an error is thrown only *once* for each
+  // (failed) time-zone.
+  std::stringstream stream;
+  std::streambuf* oldClogStreamBuf = std::clog.rdbuf(stream.rdbuf());
+  cctz::time_zone tz = fixed_time_zone(offset);
+  std::clog.rdbuf(oldClogStreamBuf);
+  if (stream.rdbuf()->in_avail()) {
+    std::stringstream msg;
+    msg << "Unable to locate TZ corresponding to offset of " << offset.count() << " seconds.\n";
+    msg << "Falling back to the `timezone` connection argument if specified, or `UTC` if not.";
+    raise_warning(msg.str());
+    return as_double(tso.stamp);
+  }
+
+  // sec is time_point
+  auto sec = convert(
+      civil_second(tso.stamp.year, tso.stamp.month, tso.stamp.day, tso.stamp.hour, tso.stamp.min, tso.stamp.sec),
+      tz);
+  return sec.time_since_epoch().count() + (tso.stamp.fract / 1000000000.0);
+}
+
 double odbc_result::as_double(nanodbc::timestamp const& ts) {
   using namespace cctz;
   auto sec = convert(
@@ -700,6 +739,7 @@ std::vector<r_type> odbc_result::column_types(nanodbc::result const& r) {
       break;
     case SQL_TIMESTAMP:
     case SQL_TYPE_TIMESTAMP:
+    case SQL_SS_TIMESTAMPOFFSET:
       types.push_back(datetime_t);
       break;
     case SQL_CHAR:
@@ -901,7 +941,7 @@ void odbc_result::assign_datetime(
   if (value.is_null(column)) {
     res = NA_REAL;
   } else {
-    auto ts = value.get<nanodbc::timestamp>(column);
+    auto ts = value.get<nanodbc::timestampoffset>(column);
     if (value.is_null(column)) {
       res = NA_REAL;
     } else {

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -162,6 +162,8 @@ private:
       size_t size);
   std::vector<std::string> column_names(nanodbc::result const& r);
 
+  double as_double(nanodbc::timestampoffset const& ts);
+
   double as_double(nanodbc::timestamp const& ts);
 
   double as_double(nanodbc::date const& dt);

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -39,7 +39,7 @@
       ! ODBC failed with error 00000 from [SQLite].
       x no such table: boopbopbopbeep (1)
       * <SQL> 'SELECT * FROM boopbopbopbeep'
-      i From 'nanodbc/nanodbc.cpp:1726'.
+      i From 'nanodbc/nanodbc.cpp:1732'.
 
 # rethrow_database_error() errors well when parse_database_error() fails
 

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -28,7 +28,7 @@
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x Data source name not found and no default driver specified
       i See `?odbc::odbcListDataSources()` to learn more.
-      i From 'nanodbc/nanodbc.cpp:1150'.
+      i From 'nanodbc/nanodbc.cpp:1156'.
 
 ---
 

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -385,7 +385,7 @@ test_that("DATETIMEOFFSET", {
     field.types = list("tz_char" = "VARCHAR(50)", "tz" = "DATETIMEOFFSET"), overwrite = TRUE)
   res <- DBI::dbReadTable(con, tbl)
   expect_s3_class(res[[2]], "POSIXct")
-  expect_equal(as.double(res[[2]][1] - as.POSIXct(res[[1]][1]), units="hours"), 2);
+  expect_equal(as.double(res[[2]][1] - as.POSIXct(res[[1]][1]), units = "hours"), 2)
 })
 
 test_that("package:odbc roundtrip test", {

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -384,7 +384,7 @@ test_that("DATETIMEOFFSET", {
   tbl <- local_table(con, "test_datetimeoffset", df,
     field.types = list("tz_char" = "VARCHAR(50)", "tz" = "DATETIMEOFFSET"), overwrite = TRUE)
   res <- DBI::dbReadTable(con, tbl)
-  expect_true("POSIXct" %in% class(res[[2]]))
+  expect_s3_class(res[[2]], "POSIXct")
   expect_equal(as.double(res[[2]][1] - as.POSIXct(res[[1]][1]), units="hours"), 2);
 })
 

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -376,6 +376,18 @@ test_that("DATETIME2 precision (#790)", {
   expect_equal(as.POSIXlt(df[[2]])$sec, as.POSIXlt(res[[2]])$sec, tolerance = 1E-7)
 })
 
+test_that("DATETIMEOFFSET", {
+  con <- test_con("SQLSERVER")
+
+  df <- data.frame(tz_char = rep("2025-05-10 19:35:03.123 +02:00", 3), tz = rep("2025-05-10 19:35:03.123 +02:00", 3))
+
+  tbl <- local_table(con, "test_datetimeoffset", df,
+    field.types = list("tz_char" = "VARCHAR(50)", "tz" = "DATETIMEOFFSET"), overwrite = TRUE)
+  res <- DBI::dbReadTable(con, tbl)
+  expect_true("POSIXct" %in% class(res[[2]]))
+  expect_equal(as.double(res[[2]][1] - as.POSIXct(res[[1]][1]), units="hours"), 2);
+})
+
 test_that("package:odbc roundtrip test", {
   test_roundtrip(test_con("SQLSERVER"))
 })


### PR DESCRIPTION
Hi:

This PR closes a longstanding TODO to better support timezones for SQL Server users.

Currently, we allow the user to specify a *fixed* timezone using the `connection.timezone` parameter.  However, some back ends ( most notably, `MSSQL`) support much more granular time+zone offset expressions, for example:

```
SELECT CURRENT_TIMESTAMP AT TIME ZONE 'Central European Standard Time'
```

which is of a data type that is not currently handled by `nanodbc` and `package:odbc`.  In particular, data would currently come back to the [R] user as a string `2025-05-10 20:07:55.410 +02:00`.  Users would then need to parse the string, manually extract the time zone, and convert at some overhead.

This PR adds a more native integration for this data type.  For example:
```
  > dbGetQuery(conn, "SELECT CAST(tz AS VARCHAR) tz_char, tz FROM (SELECT CURRENT_TIMESTAMP AT TIME ZONE 'Central European Standard Time' AS tz) TBL;")
                           tz_char                  tz
  1 2025-05-10 20:11:28.640 +02:00 2025-05-10 22:11:28
```

PR is broken up in three commits:
1. Changes to `nanodbc`.  A [FR](https://github.com/nanodbc/nanodbc/issues/379) already exists there.  I'll attempt to upstream this there.
2. Additions (no changes) to `cctz`.  These updates marry nicely against existing upstream features.  Where I made departures, I marked using `package::odbc` comments.
3. Updates to `package:odbc` business logic.

TODO:

- [x] Add news item

ping @r2evans