### PR TITLE
multiple result sets: handle mixed success

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* Fix retrieving multiple result sets from parametrized queries
+  in cases when some parameters yield empty results (#927).
+
 * Fix hang when parsing exceptionally long database errors (#916).
 
 * DB2: Fix error when writing to temp tables (#910).

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -179,6 +179,19 @@ private:
 
   std::vector<r_type> column_types(nanodbc::result const& r);
 
+  /// \brief Advance the `nanodbc::result` using `next_result`
+  /// until we encounter a non-trivial (sub-)result.
+  ///
+  /// This is a compound operation.  It will iterate through
+  /// all result sets in the `result`, via `next_result`, until we
+  /// encounted one that has both a non trivial set of
+  /// columns, as well as non trivial number of rows.  To establish the
+  /// second we call `result::next()`.  Therefore when returning to the
+  /// caller, the cursor has moved to the first row in the result
+  /// set.
+  /// \param r nanodbc::result Cursor is advanced in-situ.
+  bool nextResultSet(nanodbc::result& r);
+
   Rcpp::List result_to_dataframe(nanodbc::result& r, int n_max = -1);
 
   /// \brief Safely gets data from the given column of the current rowset.

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -391,3 +391,39 @@ test_that("DATETIMEOFFSET", {
 test_that("package:odbc roundtrip test", {
   test_roundtrip(test_con("SQLSERVER"))
 })
+
+test_that("Mixed success multiple result-sets (#924)", {
+  con <- test_con("SQLSERVER")
+
+  df <- data.frame(ID = LETTERS[1:10])
+
+  tbl <- local_table(con, "test_mixed_success_param_retrieval", df)
+  res <- DBI::dbGetQuery(
+      con,
+      "SELECT * FROM test_mixed_success_param_retrieval WHERE ID = ?",
+      params = list(c("A", "B", "C"))
+  )
+  expect_equal(nrow(res), 3)
+  res <- DBI::dbGetQuery(
+      con,
+      "SELECT * FROM test_mixed_success_param_retrieval WHERE ID = ?",
+      params = list(c("Z", "A", "B", "C"))
+  )
+  expect_equal(nrow(res), 3)
+  res <- DBI::dbGetQuery(
+      con,
+      "SELECT * FROM test_mixed_success_param_retrieval WHERE ID = ?",
+      params = list(c("A", "Z", "B", "C"))
+  )
+  expect_equal(nrow(res), 3)
+  res <- DBI::dbGetQuery(
+      con,
+      "SELECT * FROM test_mixed_success_param_retrieval WHERE ID = ?",
+      params = list(c("A", "B", "C", "Z"))
+  )
+  expect_equal(nrow(res), 3)
+})
+
+test_that("package:odbc roundtrip test", {
+  test_roundtrip(test_con("SQLSERVER"))
+})

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -423,7 +423,3 @@ test_that("Mixed success multiple result-sets (#924)", {
   )
   expect_equal(nrow(res), 3)
 })
-
-test_that("package:odbc roundtrip test", {
-  test_roundtrip(test_con("SQLSERVER"))
-})


### PR DESCRIPTION
Closes https://github.com/r-dbi/odbc/issues/924

When examining the `result` we try and check for two things:

* Whether the current result set has more rows.
* Whether there are more result sets.

With these changes, we are hopefully making these "queries" more robustly.