### PR TITLE
Ability to bind data.frames to table valued parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # odbc (development version)
 
+* SQL Server: You can now bind `data.frames` to table
+  valued parameters of stored procedures (#928).
+
+* Snowflake: Add `sf_private_key` and `sf_private_key_password`
+  connection attributes to allow users to pass the contents
+  of the PEM formatted private key to the driver directly from
+  memory (#933).
+
 * Fix retrieving multiple result sets from parametrized queries
   in cases when some parameters yield empty results (#927).
 

--- a/R/dbi-result.R
+++ b/R/dbi-result.R
@@ -139,6 +139,24 @@ setMethod("dbBind", "OdbcResult",
       return(invisible(res))
     }
 
+    paramDfs <- sapply(params, is.data.frame)
+    if (any(paramDfs)) {
+      # When binding table-valued-parameters verify that:
+      # * The `batch_rows` parameter is either unset or equal to one.
+      # * All non-tvp parameters are of length 1.
+      if (!is.na(batch_rows) && batch_rows > 1) {
+        cli::cli_warn("When passing data.frame(s) as query parameters,",
+                      "the `batch_rows` parameter must be set to 1")
+      }
+      batch_rows <- 1
+      paramLengths <- sapply(params[!paramDfs], length)
+      if (any(paramLengths > 1))
+      {
+        cli::cli_abort("When mixing data.frame(s) with other parameter types,",
+                       "all non-df parameters must be of length one")
+      }
+    }
+
     if (is.na(batch_rows)) {
       batch_rows <- length(params[[1]])
     }

--- a/R/dbi-result.R
+++ b/R/dbi-result.R
@@ -155,9 +155,7 @@ setMethod("dbBind", "OdbcResult",
         cli::cli_abort("When mixing data.frame(s) with other parameter types,
                        all non-df parameters must be of length one")
       }
-    }
-
-    if (is.na(batch_rows)) {
+    } else if (is.na(batch_rows)) {
       batch_rows <- length(params[[1]])
     }
 

--- a/R/dbi-result.R
+++ b/R/dbi-result.R
@@ -145,8 +145,8 @@ setMethod("dbBind", "OdbcResult",
       # * The `batch_rows` parameter is either unset or equal to one.
       # * All non-tvp parameters are of length 1.
       if (!is.na(batch_rows) && batch_rows > 1) {
-        cli::cli_warn("When passing data.frame(s) as query parameters,
-                      the `batch_rows` parameter must be set to 1")
+        cli::cli_warn(c("Since some parameters are data frames, {.arg batch_rows} will be overwritten to `1`.", 
+                       "Set {.code batch_rows = 1} to quiet this warning."))
       }
       batch_rows <- 1
       paramLengths <- sapply(params[!paramDfs], length)

--- a/R/dbi-result.R
+++ b/R/dbi-result.R
@@ -145,15 +145,15 @@ setMethod("dbBind", "OdbcResult",
       # * The `batch_rows` parameter is either unset or equal to one.
       # * All non-tvp parameters are of length 1.
       if (!is.na(batch_rows) && batch_rows > 1) {
-        cli::cli_warn("When passing data.frame(s) as query parameters,",
-                      "the `batch_rows` parameter must be set to 1")
+        cli::cli_warn("When passing data.frame(s) as query parameters,
+                      the `batch_rows` parameter must be set to 1")
       }
       batch_rows <- 1
       paramLengths <- sapply(params[!paramDfs], length)
       if (any(paramLengths > 1))
       {
-        cli::cli_abort("When mixing data.frame(s) with other parameter types,",
-                       "all non-df parameters must be of length one")
+        cli::cli_abort("When mixing data.frame(s) with other parameter types,
+                       all non-df parameters must be of length one")
       }
     }
 

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -5,7 +5,7 @@
 #'
 #' Details of SQL Server methods for odbc and DBI generics.
 #'
-#' Note on binding \ref{https://learn.microsoft.com/en-us/sql/relational-databases/tables/use-table-valued-parameters-database-engine}{TVPs}:
+#' Note on binding \href{https://learn.microsoft.com/en-us/sql/relational-databases/tables/use-table-valued-parameters-database-engine}{TVPs}:
 #' You can bind `data.frame`s to SQL Server TVPs when executing stored procedures with the following caveats:
 #' * All non-df parameters must be of length 1; and
 #' * The `batch_rows` parameter (to `dbBind`, for example) should be set to 1.

--- a/R/driver-sql-server.R
+++ b/R/driver-sql-server.R
@@ -5,6 +5,18 @@
 #'
 #' Details of SQL Server methods for odbc and DBI generics.
 #'
+#' Note on binding \ref{https://learn.microsoft.com/en-us/sql/relational-databases/tables/use-table-valued-parameters-database-engine}{TVPs}:
+#' You can bind `data.frame`s to SQL Server TVPs when executing stored procedures with the following caveats:
+#' * All non-df parameters must be of length 1; and
+#' * The `batch_rows` parameter (to `dbBind`, for example) should be set to 1.
+#' @examples
+#' \dontrun{
+#' # Bind `data.frame` to a TVP when executing a
+#' # stored procedure that takes three parameters:
+#' # a TVP, an INT and a VARCHAR(max).
+#' res <- dbGetQuery(conn, "{ CALL example_sproc(?, ?, ?) }",
+#'   params = list(df.data, 100, "Lorem ipsum dolor sit amet"))
+#' }
 #' @rdname SQLServer
 #' @export
 setClass("Microsoft SQL Server", contains = "OdbcConnection")

--- a/man/SQLServer.Rd
+++ b/man/SQLServer.Rd
@@ -73,7 +73,7 @@ Copied over from odbc-connection to avoid S4 dispatch NOTEs.
 }
 }
 \details{
-Note on binding \ref{https://learn.microsoft.com/en-us/sql/relational-databases/tables/use-table-valued-parameters-database-engine}{TVPs}:
+Note on binding \href{https://learn.microsoft.com/en-us/sql/relational-databases/tables/use-table-valued-parameters-database-engine}{TVPs}:
 You can bind \code{data.frame}s to SQL Server TVPs when executing stored procedures with the following caveats:
 \itemize{
 \item All non-df parameters must be of length 1; and

--- a/man/SQLServer.Rd
+++ b/man/SQLServer.Rd
@@ -72,4 +72,21 @@ actual table name.
 Copied over from odbc-connection to avoid S4 dispatch NOTEs.
 }
 }
+\details{
+Note on binding \ref{https://learn.microsoft.com/en-us/sql/relational-databases/tables/use-table-valued-parameters-database-engine}{TVPs}:
+You can bind \code{data.frame}s to SQL Server TVPs when executing stored procedures with the following caveats:
+\itemize{
+\item All non-df parameters must be of length 1; and
+\item The \code{batch_rows} parameter (to \code{dbBind}, for example) should be set to 1.
+}
+}
+\examples{
+\dontrun{
+# Bind `data.frame` to a TVP when executing a
+# stored procedure that takes three parameters:
+# a TVP, an INT and a VARCHAR(max).
+res <- dbGetQuery(conn, "{ CALL example_sproc(?, ?, ?) }",
+  params = list(df.data, 100, "Lorem ipsum dolor sit amet"))
+}
+}
 \keyword{internal}

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -1973,7 +1973,7 @@ public:
 
         describe_parameters(param_index);
         const SQLSMALLINT& param_scale = param_descr_data_.at(param_index).scale_;
-        NANODBC_ASSERT(param_scale < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        NANODBC_ASSERT(param_scale < static_cast<SQLSMALLINT>(std::numeric_limits<short>::max()));
         return static_cast<short>(param_scale);
     }
 
@@ -1986,7 +1986,7 @@ public:
 
         describe_parameters(param_index);
         const SQLSMALLINT& param_type = param_descr_data_.at(param_index).type_;
-        NANODBC_ASSERT(param_type < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        NANODBC_ASSERT(param_type < static_cast<SQLSMALLINT>(std::numeric_limits<short>::max()));
         return static_cast<short>(param_type);
     }
 
@@ -2927,7 +2927,7 @@ public:
 
         prepare_tvp_param_all();
         const SQLSMALLINT& param_scale = param_descr_data_.at(param_index).scale_;
-        NANODBC_ASSERT(param_scale < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        NANODBC_ASSERT(param_scale < static_cast<SQLSMALLINT>(std::numeric_limits<short>::max()));
         return static_cast<short>(param_scale);
     }
 
@@ -2940,7 +2940,7 @@ public:
 
         prepare_tvp_param_all();
         const SQLSMALLINT& param_type = param_descr_data_.at(param_index).type_;
-        NANODBC_ASSERT(param_type < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        NANODBC_ASSERT(param_type < static_cast<SQLSMALLINT>(std::numeric_limits<short>::max()));
         return static_cast<short>(param_type);
     }
 

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -2902,6 +2902,48 @@ public:
         }
     }
 
+    short parameters() const { return param_descr_data_.size(); }
+
+    unsigned long parameter_size(short param_index)
+    {
+        if (param_descr_data_.count(param_index))
+        {
+            return static_cast<unsigned long>(param_descr_data_.at(param_index).size_);
+        }
+
+        prepare_tvp_param_all();
+        const SQLULEN& param_size = param_descr_data_.at(param_index).size_;
+        NANODBC_ASSERT(
+            param_size < static_cast<SQLULEN>(std::numeric_limits<unsigned long>::max()));
+        return static_cast<unsigned long>(param_size);
+    }
+
+    short parameter_scale(short param_index)
+    {
+        if (param_descr_data_.count(param_index))
+        {
+            return static_cast<short>(param_descr_data_.at(param_index).scale_);
+        }
+
+        prepare_tvp_param_all();
+        const SQLSMALLINT& param_scale = param_descr_data_.at(param_index).scale_;
+        NANODBC_ASSERT(param_scale < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        return static_cast<short>(param_scale);
+    }
+
+    short parameter_type(short param_index)
+    {
+        if (param_descr_data_.count(param_index))
+        {
+            return static_cast<short>(param_descr_data_.at(param_index).type_);
+        }
+
+        prepare_tvp_param_all();
+        const SQLSMALLINT& param_type = param_descr_data_.at(param_index).type_;
+        NANODBC_ASSERT(param_type < static_cast<SQLULEN>(std::numeric_limits<short>::max()));
+        return static_cast<short>(param_type);
+    }
+
     // comparator for null sentry values
     template <class T>
     bool equals(T const& lhs, T const& rhs)
@@ -5272,8 +5314,8 @@ NANODBC_INSTANTIATE_TVP_BIND_STRINGS(wide_string_type);
 NANODBC_INSTANTIATE_TVP_BIND_VECTOR_STRINGS(string_type);
 
 #ifdef NANODBC_HAS_STD_STRING_VIEW
-/NANODBC_INSTANTIATE_TVP_BIND_VECTOR_STRINGS(std::string_view);
-/NANODBC_INSTANTIATE_TVP_BIND_VECTOR_STRINGS(wide_string_view);
+NANODBC_INSTANTIATE_TVP_BIND_VECTOR_STRINGS(std::string_view);
+NANODBC_INSTANTIATE_TVP_BIND_VECTOR_STRINGS(wide_string_view);
 #endif
 
 #undef NANODBC_INSTANTIATE_TVP_BINDS
@@ -5396,6 +5438,26 @@ void table_valued_parameter::describe_parameters(
     const std::vector<short>& scale)
 {
     impl_->describe_parameters(idx, type, size, scale);
+}
+
+short table_valued_parameter::parameters() const
+{
+    return impl_->parameters();
+}
+
+unsigned long table_valued_parameter::parameter_size(short param_index) const
+{
+    return impl_->parameter_size(param_index);
+}
+
+short table_valued_parameter::parameter_scale(short param_index) const
+{
+    return impl_->parameter_scale(param_index);
+}
+
+short table_valued_parameter::parameter_type(short param_index) const
+{
+    return impl_->parameter_type(param_index);
 }
 } // namespace nanodbc
 #endif // NANODBC_DISABLE_MSSQL_TVP

--- a/src/nanodbc/nanodbc.h
+++ b/src/nanodbc/nanodbc.h
@@ -648,6 +648,19 @@ public:
         const std::vector<unsigned long>& size,
         const std::vector<short>& scale);
 
+    /// \brief Returns the number of columns in the table valued parameter.
+    /// \throws database_error
+    short parameters() const;
+
+    /// \brief Returns parameter size for indicated column in the TVP.
+    unsigned long parameter_size(short param_index) const;
+
+    /// \brief Returns parameter scale for indicated column in the TVP.
+    short parameter_scale(short param_index) const;
+
+    /// \brief Returns parameter type for indicated column in the TVP.
+    short parameter_type(short param_index) const;
+
 private:
     class table_valued_parameter_impl;
     friend class statement;

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -5,6 +5,10 @@
 #include <chrono>
 #include <memory>
 
+#if R_VERSION < R_Version(4, 5, 0)
+#define Rf_isDataFrame(x) Rf_isFrame(x)
+#endif
+
 #ifndef SQL_SS_TIME2
 #define SQL_SS_TIME2 (-154)
 #endif
@@ -88,39 +92,44 @@ void odbc_result::execute() {
   }
 }
 
+template<typename T>
 void odbc_result::bind_columns(
-    nanodbc::statement& statement,
+    T& obj,
     r_type type,
     Rcpp::List const& data,
     short column,
     size_t start,
-    size_t size) {
+    size_t size,
+    param_data& buffers) {
 
   switch (type) {
   case logical_t:
-    bind_logical(*s_, data, column, start, size);
+    bind_logical(obj, data, column, start, size, buffers);
     break;
   case date_t:
-    bind_date(*s_, data, column, start, size);
+    bind_date(obj, data, column, start, size, buffers);
     break;
   case datetime_t:
-    bind_datetime(*s_, data, column, start, size);
+    bind_datetime(obj, data, column, start, size, buffers);
     break;
   case double_t:
-    bind_double(*s_, data, column, start, size);
+    bind_double(obj, data, column, start, size, buffers);
     break;
   case integer_t:
-    bind_integer(*s_, data, column, start, size);
+    bind_integer(obj, data, column, start, size, buffers);
     break;
   case odbc::time_t:
-    bind_time(*s_, data, column, start, size);
+    bind_time(obj, data, column, start, size, buffers);
     break;
   case ustring_t:
   case string_t:
-    bind_string(*s_, data, column, start, size);
+    bind_string(obj, data, column, start, size, buffers);
     break;
   case raw_t:
-    bind_raw(*s_, data, column, start, size);
+    bind_raw(obj, data, column, start, size, buffers);
+    break;
+  case dataframe_t:
+    bind_df(obj, data, column, start, size, buffers);
     break;
   default:
     Rcpp::stop("Not yet implemented (%s)!", type);
@@ -164,7 +173,7 @@ void odbc_result::bind_list(
     Rcpp::stop(
         "Query requires '%i' params; '%i' supplied.", s_->parameters(), ncols);
   }
-  size_t nrows = Rf_length(x[0]);
+  size_t nrows = get_parameter_rows(x);
   size_t start = 0;
   std::unique_ptr<nanodbc::transaction> t;
   if (use_transaction && c_->supports_transactions()) {
@@ -178,7 +187,7 @@ void odbc_result::bind_list(
     clear_buffers();
 
     for (short col = 0; col < ncols; ++col) {
-      bind_columns(*s_, types[col], x, col, start, size);
+      bind_columns(*s_, types[col], x, col, start, size, buffers_);
     }
     r_ = std::make_shared<nanodbc::result>(nanodbc::execute(*s_, size));
     num_columns_ = r_->columns();
@@ -252,173 +261,146 @@ odbc_result::~odbc_result() {
 }
 
 void odbc_result::clear_buffers() {
-  strings_.clear();
-  raws_.clear();
-  times_.clear();
-  timestamps_.clear();
-  dates_.clear();
-  nulls_.clear();
+  buffers_.strings_.clear();
+  buffers_.raws_.clear();
+  buffers_.times_.clear();
+  buffers_.timestamps_.clear();
+  buffers_.dates_.clear();
+  buffers_.nulls_.clear();
+  tvp_buffers_.clear();
 }
 
+template<typename T>
 void odbc_result::bind_logical(
-    nanodbc::statement& statement,
+    T& obj,
     Rcpp::List const& data,
     short column,
     size_t start,
-    size_t size) {
-  nulls_[column] = std::vector<uint8_t>(size, false);
+    size_t size,
+    param_data& buffers) {
+  buffers.nulls_[column] = std::vector<uint8_t>(size, false);
   auto vector = LOGICAL(data[column]);
   for (size_t i = 0; i < size; ++i) {
     if (vector[start + i] == NA_LOGICAL) {
-      nulls_[column][i] = true;
+      buffers.nulls_[column][i] = true;
     }
   }
   auto t = reinterpret_cast<const int*>(&LOGICAL(data[column])[start]);
-  statement.bind<int>(
-      column, t, size, reinterpret_cast<bool*>(nulls_[column].data()));
+  obj.template bind<int>(
+      column, t, size, reinterpret_cast<bool*>(buffers.nulls_[column].data()));
 }
 
+template<typename T>
 void odbc_result::bind_integer(
-    nanodbc::statement& statement,
+    T& obj,
     Rcpp::List const& data,
     short column,
     size_t start,
-    size_t size) {
-  nulls_[column] = std::vector<uint8_t>(size, false);
+    size_t size,
+    param_data& buffers) {
+  buffers.nulls_[column] = std::vector<uint8_t>(size, false);
 
   auto vector = INTEGER(data[column]);
   for (size_t i = 0; i < size; ++i) {
     if (vector[start + i] == NA_INTEGER) {
-      nulls_[column][i] = true;
+      buffers.nulls_[column][i] = true;
     }
   }
-  statement.bind(
+  obj.bind(
       column,
       &INTEGER(data[column])[start],
       size,
-      reinterpret_cast<bool*>(nulls_[column].data()));
+      reinterpret_cast<bool*>(buffers.nulls_[column].data()));
 }
 
 // We cannot use a sentinel for doubles becuase NaN != NaN for all values
 // of NaN, even if the bits are the same.
+template<typename T>
 void odbc_result::bind_double(
-    nanodbc::statement& statement,
+    T& obj,
     Rcpp::List const& data,
     short column,
     size_t start,
-    size_t size) {
-  nulls_[column] = std::vector<uint8_t>(size, false);
+    size_t size,
+    param_data& buffers) {
+  buffers.nulls_[column] = std::vector<uint8_t>(size, false);
 
   auto vector = REAL(data[column]);
   for (size_t i = 0; i < size; ++i) {
     if (ISNA(vector[start + i])) {
-      nulls_[column][i] = true;
+      buffers.nulls_[column][i] = true;
     }
   }
 
-  statement.bind(
+  obj.bind(
       column,
       &vector[start],
       size,
-      reinterpret_cast<bool*>(nulls_[column].data()));
+      reinterpret_cast<bool*>(buffers.nulls_[column].data()));
 }
 
+template<typename T>
 void odbc_result::bind_string(
-    nanodbc::statement& statement,
+    T& obj,
     Rcpp::List const& data,
     short column,
     size_t start,
-    size_t size) {
-  nulls_[column] = std::vector<uint8_t>(size, false);
+    size_t size,
+    param_data& buffers) {
+  buffers.nulls_[column] = std::vector<uint8_t>(size, false);
   for (size_t i = 0; i < size; ++i) {
     auto value = STRING_ELT(data[column], start + i);
     if (value == NA_STRING) {
-      nulls_[column][i] = true;
+      buffers.nulls_[column][i] = true;
     }
     const char* v = CHAR(value);
-    strings_[column].push_back(v);
+    buffers.strings_[column].push_back(v);
   }
 
-  statement.bind_strings(
-      column, strings_[column], reinterpret_cast<bool*>(nulls_[column].data()));
+  obj.bind_strings(
+      column, buffers.strings_[column], reinterpret_cast<bool*>(buffers.nulls_[column].data()));
 }
+
+template<typename T>
 void odbc_result::bind_raw(
-    nanodbc::statement& statement,
+    T& obj,
     Rcpp::List const& data,
     short column,
     size_t start,
-    size_t size) {
-  nulls_[column] = std::vector<uint8_t>(size, false);
+    size_t size,
+    param_data& buffers) {
+  buffers.nulls_[column] = std::vector<uint8_t>(size, false);
   for (size_t i = 0; i < size; ++i) {
     SEXP value = VECTOR_ELT(data[column], start + i);
     if (TYPEOF(value) == NILSXP) {
-      nulls_[column][i] = true;
-      raws_[column].push_back(std::vector<uint8_t>());
+      buffers.nulls_[column][i] = true;
+      buffers.raws_[column].push_back(std::vector<uint8_t>());
     } else {
-      raws_[column].push_back(
+      buffers.raws_[column].push_back(
           std::vector<uint8_t>(RAW(value), RAW(value) + Rf_length(value)));
     }
   }
 
-  statement.bind(
-      column, raws_[column], reinterpret_cast<bool*>(nulls_[column].data()));
+  obj.bind(
+      column, buffers.raws_[column], reinterpret_cast<bool*>(buffers.nulls_[column].data()));
 }
 
-nanodbc::timestamp odbc_result::as_timestamp(double value, unsigned long long factor, unsigned long long pad) {
-  nanodbc::timestamp ts;
-  auto frac = modf(value, &value);
-
-  using namespace std::chrono;
-  auto utc_time = system_clock::from_time_t(static_cast<std::time_t>(value));
-
-  auto civil_time = cctz::convert(utc_time, c_->timezone());
-  ts.fract = (std::int32_t)(frac * factor) * pad;
-
-  ts.sec = civil_time.second();
-  ts.min = civil_time.minute();
-  ts.hour = civil_time.hour();
-  ts.day = civil_time.day();
-  ts.month = civil_time.month();
-  ts.year = civil_time.year();
-  return ts;
-}
-
-nanodbc::date odbc_result::as_date(double value) {
-  nanodbc::date dt;
-
-  using namespace std::chrono;
-  auto utc_time = system_clock::from_time_t(static_cast<std::time_t>(value));
-
-  auto civil_time = cctz::convert(utc_time, cctz::utc_time_zone());
-  dt.day = civil_time.day();
-  dt.month = civil_time.month();
-  dt.year = civil_time.year();
-  return dt;
-}
-
-nanodbc::time odbc_result::as_time(double value) {
-  nanodbc::time ts;
-  ts.hour = value / seconds_in_hour_;
-  auto remainder = static_cast<int>(value) % seconds_in_hour_;
-  ts.min = remainder / seconds_in_minute_;
-  ts.sec = remainder % seconds_in_minute_;
-  return ts;
-}
-
+template<typename T>
 void odbc_result::bind_datetime(
-    nanodbc::statement& statement,
+    T& obj,
     Rcpp::List const& data,
     short column,
     size_t start,
-    size_t size) {
+    size_t size,
+    param_data& buffers) {
 
-  nulls_[column] = std::vector<uint8_t>(size, false);
+  buffers.nulls_[column] = std::vector<uint8_t>(size, false);
   auto d = REAL(data[column]);
 
   nanodbc::timestamp ts;
   short precision = 3;
   try {
-    precision = statement.parameter_scale(column);
+    precision = obj.parameter_scale(column);
   } catch (const nanodbc::database_error& e) {
     raise_warning("Unable to discern datetime precision. Using default (3).");
   };
@@ -431,71 +413,100 @@ void odbc_result::bind_datetime(
   for (size_t i = 0; i < size; ++i) {
     auto value = d[start + i];
     if (ISNA(value)) {
-      nulls_[column][i] = true;
+      buffers.nulls_[column][i] = true;
     } else {
       ts = as_timestamp(value, prec_adj, pad);
     }
-    timestamps_[column].push_back(ts);
+    buffers.timestamps_[column].push_back(ts);
   }
-  statement.bind(
+  obj.bind(
       column,
-      timestamps_[column].data(),
+      buffers.timestamps_[column].data(),
       size,
-      reinterpret_cast<bool*>(nulls_[column].data()));
+      reinterpret_cast<bool*>(buffers.nulls_[column].data()));
 }
+
+template<typename T>
 void odbc_result::bind_date(
-    nanodbc::statement& statement,
+    T& obj,
     Rcpp::List const& data,
     short column,
     size_t start,
-    size_t size) {
+    size_t size,
+    param_data& buffers) {
 
-  nulls_[column] = std::vector<uint8_t>(size, false);
+  buffers.nulls_[column] = std::vector<uint8_t>(size, false);
   auto d = REAL(data[column]);
 
   nanodbc::date dt;
   for (size_t i = 0; i < size; ++i) {
     auto value = d[start + i] * seconds_in_day_;
     if (ISNA(value)) {
-      nulls_[column][i] = true;
+      buffers.nulls_[column][i] = true;
     } else {
       dt = as_date(value);
     }
-    dates_[column].push_back(dt);
+    buffers.dates_[column].push_back(dt);
   }
-  statement.bind(
+  obj.bind(
       column,
-      dates_[column].data(),
+      buffers.dates_[column].data(),
       size,
-      reinterpret_cast<bool*>(nulls_[column].data()));
+      reinterpret_cast<bool*>(buffers.nulls_[column].data()));
 }
 
+template<typename T>
 void odbc_result::bind_time(
-    nanodbc::statement& statement,
+    T& obj,
     Rcpp::List const& data,
     short column,
     size_t start,
-    size_t size) {
+    size_t size,
+    param_data& buffers) {
 
-  nulls_[column] = std::vector<uint8_t>(size, false);
+  buffers.nulls_[column] = std::vector<uint8_t>(size, false);
   auto d = REAL(data[column]);
 
   nanodbc::time ts;
   for (size_t i = 0; i < size; ++i) {
     auto value = d[start + i];
     if (ISNA(value)) {
-      nulls_[column][i] = true;
+      buffers.nulls_[column][i] = true;
     } else {
       ts = as_time(value);
     }
-    times_[column].push_back(ts);
+    buffers.times_[column].push_back(ts);
   }
-  statement.bind(
+  obj.bind(
       column,
-      times_[column].data(),
+      buffers.times_[column].data(),
       size,
-      reinterpret_cast<bool*>(nulls_[column].data()));
+      reinterpret_cast<bool*>(buffers.nulls_[column].data()));
 }
+
+template<typename T>
+void odbc_result::bind_df(
+    T& obj,
+    Rcpp::List const& data,
+    short column,
+    size_t start, /* ignored */
+    size_t size,  /* ignored */
+    param_data& buffers) {
+
+  const Rcpp::List& df = data[column];
+  auto types = column_types(df);
+  auto ncols = df.size();
+  size_t nrows = Rf_length(df[0]);
+  auto param = nanodbc::table_valued_parameter(*s_, column, nrows);
+
+  for (short col = 0; col < ncols; ++col) {
+    bind_columns(param, types[col], df, col, 0, nrows, tvp_buffers_[column]);
+  }
+  param.close();
+
+  return;
+}
+
 std::vector<std::string> odbc_result::column_names(nanodbc::result const& r) {
   std::vector<std::string> names;
   names.reserve(num_columns_);
@@ -546,6 +557,47 @@ double odbc_result::as_double(nanodbc::timestampoffset const& tso) {
   return sec.time_since_epoch().count() + (tso.stamp.fract / 1000000000.0);
 }
 
+nanodbc::timestamp odbc_result::as_timestamp(double value, unsigned long long factor, unsigned long long pad) {
+  nanodbc::timestamp ts;
+  auto frac = modf(value, &value);
+
+  using namespace std::chrono;
+  auto utc_time = system_clock::from_time_t(static_cast<std::time_t>(value));
+
+  auto civil_time = cctz::convert(utc_time, c_->timezone());
+  ts.fract = (std::int32_t)(frac * factor) * pad;
+
+  ts.sec = civil_time.second();
+  ts.min = civil_time.minute();
+  ts.hour = civil_time.hour();
+  ts.day = civil_time.day();
+  ts.month = civil_time.month();
+  ts.year = civil_time.year();
+  return ts;
+}
+
+nanodbc::date odbc_result::as_date(double value) {
+  nanodbc::date dt;
+
+  using namespace std::chrono;
+  auto utc_time = system_clock::from_time_t(static_cast<std::time_t>(value));
+
+  auto civil_time = cctz::convert(utc_time, cctz::utc_time_zone());
+  dt.day = civil_time.day();
+  dt.month = civil_time.month();
+  dt.year = civil_time.year();
+  return dt;
+}
+
+nanodbc::time odbc_result::as_time(double value) {
+  nanodbc::time ts;
+  ts.hour = value / seconds_in_hour_;
+  auto remainder = static_cast<int>(value) % seconds_in_hour_;
+  ts.min = remainder / seconds_in_minute_;
+  ts.sec = remainder % seconds_in_minute_;
+  return ts;
+}
+
 double odbc_result::as_double(nanodbc::timestamp const& ts) {
   using namespace cctz;
   auto sec = convert(
@@ -586,6 +638,7 @@ Rcpp::List odbc_result::create_dataframe(
       out[j] = Rf_allocVector(STRSXP, n);
       break;
     case raw_t:
+    case dataframe_t:
       out[j] = Rf_allocVector(VECSXP, n);
       break;
     case logical_t:
@@ -647,6 +700,10 @@ std::vector<r_type> odbc_result::column_types(Rcpp::List const& list) {
   std::vector<r_type> types;
   types.reserve(list.size());
   for (short i = 0; i < list.size(); ++i) {
+    if (Rf_isDataFrame(list[i])) {
+      types.push_back(dataframe_t);
+      continue;
+    }
     switch (TYPEOF(list[i])) {
     case LGLSXP:
       types.push_back(logical_t);
@@ -1009,4 +1066,50 @@ void odbc_result::assign_raw(
   std::copy(data.begin(), data.end(), RAW(bytes));
   SET_VECTOR_ELT(out[column], row, bytes);
 }
+
+// Infer number of rows across parameters.
+//
+// In keeping with how we have done this historically,
+// use the length of the first non-data.frame parameter.
+//
+// In the future we should attempt to do some validation.  For example
+// * Are all parameters of same length
+// * If there is a TVP, are there other parameters of length > 1
+size_t odbc_result::get_parameter_rows(Rcpp::List const& x) {
+  auto ncols = x.size();
+  size_t nrows = 0;
+  for (short col = 0; col < ncols; ++col) {
+    if (Rf_isDataFrame(x[col])) {
+      nrows = 1;
+      continue;
+    }
+    nrows = Rf_length(x[col]);
+    break;
+  }
+  return nrows;
+}
+
+# define R_ODBC_INSTANTIATE_BINDS(type)                                   \
+  template void odbc_result::bind_columns(type& obj, r_type,              \
+      Rcpp::List const&, short, size_t, size_t, param_data&);             \
+  template void odbc_result::bind_logical(type& obj,                      \
+      Rcpp::List const&, short, size_t, size_t, param_data&);             \
+  template void odbc_result::bind_integer(type& obj,                      \
+      Rcpp::List const&, short, size_t, size_t, param_data&);             \
+  template void odbc_result::bind_double(type& obj,                       \
+      Rcpp::List const&, short, size_t, size_t, param_data&);             \
+  template void odbc_result::bind_string(type& obj,                       \
+      Rcpp::List const&, short, size_t, size_t, param_data&);             \
+  template void odbc_result::bind_raw(type& obj,                          \
+      Rcpp::List const&, short, size_t, size_t, param_data&);             \
+  template void odbc_result::bind_datetime(type& obj,                     \
+      Rcpp::List const&, short, size_t, size_t, param_data&);             \
+  template void odbc_result::bind_date(type& obj,                         \
+      Rcpp::List const&, short, size_t, size_t, param_data&);             \
+  template void odbc_result::bind_time(type& obj,                         \
+      Rcpp::List const&, short, size_t, size_t, param_data&);             \
+  template void odbc_result::bind_df(type& obj,                           \
+      Rcpp::List const&, short, size_t, size_t, param_data&);
+R_ODBC_INSTANTIATE_BINDS(nanodbc::statement);
+R_ODBC_INSTANTIATE_BINDS(nanodbc::table_valued_parameter);
 } // namespace odbc

--- a/src/r_types.h
+++ b/src/r_types.h
@@ -15,5 +15,6 @@ typedef enum {
   string_t,
   ustring_t,
   raw_t,
+  dataframe_t,
 } r_type;
 }

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -451,7 +451,7 @@ test_that("Table-valued parameters", {
     dbExecute(con, "DROP TYPE tvp_param")
   })
 
-  df.param <- data.frame(int = 1:10, bigint=1:10, vrchr = rownames(mtcars)[1:10],
+  df.param <- data.frame(int = 1:10, bigint = 1:10, vrchr = rownames(mtcars)[1:10],
     vrchr2 = as.character(iris$Species[1:10]), vrchr3 = LETTERS[1:10], stringsAsFactors = FALSE)
   res <- dbGetQuery(con, "{ CALL tvp_test(?, ?, ?) }", params = list(100, df.param, "Lorem ipsum dolor sit amet"))
 


### PR DESCRIPTION
Hi:

There are two commits in this PR.

* One is a backport of some [upstream changes](https://github.com/nanodbc/nanodbc/pull/426) in `nanodbc` that complete the TVP API.
* Another is adding [R] bindings to make it possible to bind `data.frame`s to TVPs.

It is relatively common for SQL Server developers to create sprocs that take a [table valued parameters](https://learn.microsoft.com/en-us/sql/relational-databases/tables/use-table-valued-parameters-database-engine?view=sql-server-ver17) (TVP) as an argument, as traditionally this has been one of the more efficient ways to organize the arguments without needing to use intermediate storage.
Until now, we didn't have a way to execute these sprocs from [R]; this PR makes it possible to do so, by adding the ability to bind `data.frame`s to TVP.

There is example usage in the unit tests.  I was thinking about pulling those out as stand alone examples, but was at a bit of a loss of where to put them.  Perhaps in the documentation of `SQLServer-class`? Not sure, let me know if you have suggestions.

I wonder if long term we could benefit from some back-end specific vignettes.

This PR is related to #898 (though, that one stands on its own).