### PR TITLE
Add Databricks support for service principals when running in Posit Connect with connectcreds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     rlang (>= 1.1.0),
     vctrs
 Suggests:
-    connectcreds,
+    connectcreds (>= 0.2.0),
     covr,
     DBItest,
     httr2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,9 @@
   multiple named connections (via the new `connection_name` argument), and
   generally improves compatibility with the Snowflake CLI and Python ecosystem.
 
+* `databricks()` now detects service principal credentials when running on Posit
+  Connect (@tnederlof, #930)
+
 # odbc 1.6.4
 
 * Fix writing of [R] date/time values that have integer storage. (#952)

--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -15,9 +15,9 @@ NULL
 #' model, with support for personal access tokens, OAuth machine-to-machine
 #' credentials, and OAuth user-to-machine credentials supplied via Posit
 #' Workbench or the Databricks CLI on desktop. It can also detect viewer-based
-#' credentials on Posit Connect if the \pkg{connectcreds} package is
-#' installed. All of these credentials are detected automatically if present
-#' using [standard environment variables](https://docs.databricks.com/en/dev-tools/auth.html#environment-variables-and-fields-for-client-unified-authentication).
+#' and service principal credentials on Posit Connect if the \pkg{connectcreds}
+#' package is installed. All of these credentials are detected automatically if
+#' present using [standard environment variables](https://docs.databricks.com/en/dev-tools/auth.html#environment-variables-and-fields-for-client-unified-authentication).
 #'
 #' In addition, on macOS platforms, the `dbConnect()` method will check
 #' for irregularities with how the driver is configured,
@@ -51,12 +51,13 @@ NULL
 #'   httpPath = "sql/protocolv1/o/4425955464597947/1026-023828-vn51jugj"
 #' )
 #'
-#' # Use credentials from the viewer (when possible) in a Shiny app
-#' # deployed to Posit Connect.
+#' # Use credentials from the viewer or a service principal (when possible) in
+#' # a Shiny app deployed to Posit Connect.
 #' library(connectcreds)
 #' server <- function(input, output, session) {
 #'   conn <- DBI::dbConnect(
 #'     odbc::databricks(),
+#'     workspace = "https://example.cloud.databricks.com",
 #'     httpPath = "sql/protocolv1/o/4425955464597947/1026-023828-vn51jugj"
 #'   )
 #' }
@@ -136,9 +137,12 @@ databricks_args <- function(httpPath,
     if (running_on_connect()) {
       msg <- c(
         msg,
-        "i" = "Or consider enabling Posit Connect's Databricks integration \
-              for viewer-based credentials. See {.url \
-              https://docs.posit.co/connect/user/oauth-integrations/#adding-oauth-integrations-to-deployed-content}
+        "i" = "Or consider enabling Posit Connect's Databricks integration. \
+              For viewer-based credentials, see {.url \
+              https://docs.posit.co/connect/user/oauth-integrations/#viewer-oauth-integrations}
+              for details. \
+              For service principal credentials, see {.url \
+              https://docs.posit.co/connect/user/oauth-integrations/#service-account-oauth-integrations}
               for details."
       )
     }
@@ -222,6 +226,15 @@ databricks_auth_args <- function(host, uid = NULL, pwd = NULL) {
   workspace <- paste0("https://", host)
   if (is_installed("connectcreds") && connectcreds::has_viewer_token(workspace)) {
     token <- connectcreds::connect_viewer_token(workspace)
+    return(list(
+      authMech = 11,
+      auth_flow = 0,
+      auth_accesstoken = token$access_token
+    ))
+  }
+
+  if (is_installed("connectcreds") && connectcreds::has_service_account_token(workspace)) {
+    token <- connectcreds::connect_service_account_token(workspace)
     return(list(
       authMech = 11,
       auth_flow = 0,

--- a/man/databricks.Rd
+++ b/man/databricks.Rd
@@ -57,9 +57,9 @@ implements a subset of the \href{https://docs.databricks.com/en/dev-tools/auth.h
 model, with support for personal access tokens, OAuth machine-to-machine
 credentials, and OAuth user-to-machine credentials supplied via Posit
 Workbench or the Databricks CLI on desktop. It can also detect viewer-based
-credentials on Posit Connect if the \pkg{connectcreds} package is
-installed. All of these credentials are detected automatically if present
-using \href{https://docs.databricks.com/en/dev-tools/auth.html#environment-variables-and-fields-for-client-unified-authentication}{standard environment variables}.
+and service principal credentials on Posit Connect if the \pkg{connectcreds}
+package is installed. All of these credentials are detected automatically if
+present using \href{https://docs.databricks.com/en/dev-tools/auth.html#environment-variables-and-fields-for-client-unified-authentication}{standard environment variables}.
 
 In addition, on macOS platforms, the \code{dbConnect()} method will check
 for irregularities with how the driver is configured,
@@ -73,12 +73,13 @@ DBI::dbConnect(
   httpPath = "sql/protocolv1/o/4425955464597947/1026-023828-vn51jugj"
 )
 
-# Use credentials from the viewer (when possible) in a Shiny app
-# deployed to Posit Connect.
+# Use credentials from the viewer or a service principal (when possible) in
+# a Shiny app deployed to Posit Connect.
 library(connectcreds)
 server <- function(input, output, session) {
   conn <- DBI::dbConnect(
     odbc::databricks(),
+    workspace = "https://example.cloud.databricks.com",
     httpPath = "sql/protocolv1/o/4425955464597947/1026-023828-vn51jugj"
   )
 }

--- a/tests/testthat/_snaps/driver-databricks.md
+++ b/tests/testthat/_snaps/driver-databricks.md
@@ -58,7 +58,7 @@
       Error in `dbConnect()`:
       ! `httpPath` must be a single string or `NULL`, not the number 1.
 
-# we hint viewer-based credentials on Connect
+# we hint viewer-based and service principal credentials on Connect
 
     Code
       databricks_args(workspace = "workspace", httpPath = "path", driver = "driver")
@@ -66,5 +66,5 @@
       Error in `DBI::dbConnect()`:
       ! Failed to detect ambient Databricks credentials.
       i Supply `uid` and `pwd` to authenticate manually.
-      i Or consider enabling Posit Connect's Databricks integration for viewer-based credentials. See <https://docs.posit.co/connect/user/oauth-integrations/#adding-oauth-integrations-to-deployed-content> for details.
+      i Or consider enabling Posit Connect's Databricks integration.  For viewer-based credentials, see <https://docs.posit.co/connect/user/oauth-integrations/#viewer-oauth-integrations> for details.  For service principal credentials, see <https://docs.posit.co/connect/user/oauth-integrations/#service-account-oauth-integrations> for details.
 

--- a/tests/testthat/test-driver-databricks.R
+++ b/tests/testthat/test-driver-databricks.R
@@ -153,7 +153,7 @@ test_that("Workbench-managed credentials are ignored for other hosts", {
   expect_equal(databricks_auth_args(host = "some-host"), NULL)
 })
 
-test_that("we hint viewer-based credentials on Connect", {
+test_that("we hint viewer-based and service principal credentials on Connect", {
   local_mocked_bindings(
     running_on_connect = function() TRUE
   )


### PR DESCRIPTION
~~**CANNOT MERGE until `connectcreds` release**~~

This commit adds support for service principal credentials managed by
Posit Connect alongside our existing support of viewer-based
credentials. The meat of this is handled by the `connectcreds` package.

Documentation and unit test updates are included.

Addresses: https://github.com/r-dbi/odbc/issues/930

