### PR TITLE
snowflake: add private key connection attributes

### DIFF
--- a/R/odbc-connection.R
+++ b/R/odbc-connection.R
@@ -199,9 +199,8 @@ needs_quoting <- function(x) {
 #'   with limited support away from the OEM Microsoft driver.
 #' * `sf_private_key`: This parameter is specific to establishing a connection
 #'   to `snowflake` and is understood by both OEM, as well as `Posit`
-#'   pro drivers.  Argument hould be a string (scalar); in particular the
-#'   contents of your BASE64 encoded private key (file).  String should
-#'   include newline characters as well as key header and footer.  Note,
+#'   pro drivers.  Argument should be a string (scalar); in particular a
+#'   PEM-encoded private key.  Note,
 #'   if using private key authentication, the `authenticator` connection
 #'   string attribute must be set to `SNOWFLAKE_JWT`.
 #'   Using this *connection* attribute is an alternative to using the

--- a/R/odbc-connection.R
+++ b/R/odbc-connection.R
@@ -197,6 +197,17 @@ needs_quoting <- function(x) {
 #' * `azure_token`: This should be a string scalar; in particular Azure Active
 #'   Directory authentication token.  Only for use with Microsoft SQL Server and
 #'   with limited support away from the OEM Microsoft driver.
+#' * `sf_private_key`: This parameter is specific to establishing a connection
+#'   to `snowflake` and is understood by both OEM, as well as `Posit`
+#'   pro drivers.  Argument hould be a string (scalar); in particular the
+#'   contents of your BASE64 encoded private key (file).  String should
+#'   include newline characters as well as key header and footer.  Note,
+#'   if using private key authentication, the `authenticator` connection
+#'   string attribute must be set to `SNOWFLAKE_JWT`.
+#'   Using this *connection* attribute is an alternative to using the
+#'   `PRIV_KEY_FILE` connection string attribute.
+#' * `sf_private_key_password`: If key passed using `sf_private_key` is
+#'   encrypted, you can use this attribute to communicate the password.
 #' @rdname ConnectionAttributes
 #' @keywords internal
 #' @aliases ConnectionAttributes
@@ -209,9 +220,15 @@ needs_quoting <- function(x) {
 #'   dsn = "my_azure_mssql_db",
 #'   Encrypt = "yes",
 #'   attributes = list("azure_token" = .token)
-#' )
+#'
+#' conn <- dbConnect(
+#'  odbc::odbc(),
+#'  dsn = "snowflake",
+#'  attributes = list("sf_private_key" = paste(readLines("<path-to-private-key-file>"), collapse="\n"),
+#'                    "sf_private_key_password" = "<optional-private-key-encryption-password>"),
+#'  authenticator = "SNOWFLAKE_JWT")
 #' }
-SUPPORTED_CONNECTION_ATTRIBUTES <- c("azure_token")
+SUPPORTED_CONNECTION_ATTRIBUTES <- c("azure_token", "sf_private_key", "sf_private_key_password")
 
 #' Odbc Connection Methods
 #'

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -55,7 +55,7 @@ namespace utils {
               SQL_COPT_SS_ACCESS_TOKEN, SQL_IS_POINTER, buffer.get()));
         buffer_context.push_back(buffer);
       }
-      if (r_attributes.containsElementNamed( "sf_private_key" ) &&
+      if (r_attributes.containsElementNamed("sf_private_key") &&
           !Rf_isNull(r_attributes["sf_private_key"]))
       {
         std::shared_ptr<std::string> priv_key =
@@ -67,8 +67,8 @@ namespace utils {
                SQL_SF_CONN_ATTR_PRIV_KEY_CONTENT, SQL_NTS, buffer.get()));
         buffer_context.push_back(buffer);
       }
-      if ( r_attributes.containsElementNamed( "sf_private_key_password" ) &&
-          !Rf_isNull(r_attributes["sf_private_key_password"]) )
+      if (r_attributes.containsElementNamed("sf_private_key_password") &&
+          !Rf_isNull(r_attributes["sf_private_key_password"]))
       {
         std::shared_ptr<std::string> key_pass =
           std::make_shared<std::string>(Rcpp::as<std::string>(r_attributes["sf_private_key_password"]));

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -144,7 +144,7 @@
     Condition
       Error in `dbConnect()`:
       ! `attributes` does not support the connection attribute "boop".
-      i Allowed connection attribute is "azure_token".
+      i Allowed connection attributes are "azure_token", "sf_private_key", and "sf_private_key_password".
 
 ---
 
@@ -153,7 +153,7 @@
     Condition
       Error in `dbConnect()`:
       ! `attributes` does not support the connection attributes "boop" and "beep".
-      i Allowed connection attribute is "azure_token".
+      i Allowed connection attributes are "azure_token", "sf_private_key", and "sf_private_key_password".
 
 # configure_simba() errors informatively on failure to install unixODBC
 


### PR DESCRIPTION
Hi:

Closes #923 

Following up on a user-reported use case - one where using the [suggested](https://posit.co/blog/running-tidymodel-prediction-workflows-inside-databases/) workflow for authenticating with RSA credentials, raises a security concern when a key is written to disk.

With these changes users can communicate the key to the driver as a location in memory, without needing to store it to disk.


Had a chance to test these changes locally with both `OEM` and `pro` drivers.  Not sure how to organize a unit test for them.