### PR TITLE
nanodbc: move pragma to make sure it is effective

### DIFF
--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -369,9 +369,9 @@ inline void convert(const std::string& in, wide_string_type& out)
         MultiByteToWideChar(CP_UTF8, 0, &in[0], static_cast<int>(in.size()), nullptr, 0);
     out.resize(size_needed);
     MultiByteToWideChar(CP_UTF8, 0, &in[0], static_cast<int>(in.size()), &out[0], size_needed);
+#else
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else
     out = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().from_bytes(in);
 # pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Closes #940 

Pretty self explanatory.  I think we've had this errant `#if / #else` for a while, but I exposed it in https://github.com/r-dbi/odbc/commit/258b74a71f765f905403701ee181d904550a9844 when I uncovered the whole method.