### PR TITLE
mssql: DATETIMEOFFSET: When transforming to UTC, use ISO 8601 convention

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
 # odbc (development version)
 
+* SQL Server:
+     - Fix time zone interpretation in `DATETIMEOFFSET` data; now follows
+       ISO 8061 convention.  (#946)
+
 # odbc 1.6.3
 
-Addressed a compiler warning on `r-devel-linux-x86_64-fedora-clang` (#941).
+* Addressed a compiler warning on `r-devel-linux-x86_64-fedora-clang` (#941).
 
 # odbc 1.6.2
 

--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -540,7 +540,15 @@ double odbc_result::as_double(nanodbc::timestampoffset const& tso) {
   // (failed) time-zone.
   std::stringstream stream;
   std::streambuf* oldClogStreamBuf = std::clog.rdbuf(stream.rdbuf());
-  cctz::time_zone tz = fixed_time_zone(offset);
+  // We are looking up fixed offsets
+  // using "Etc/GMT" as the prefix.  The convention
+  // for those zones/offsets is opposite directionally
+  // from the ISO 8061 database convention.  See:
+  // https://github.com/eggert/tz/blob/main/etcetera#L37
+  // https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
+  // As a result, look up the time-zone using the
+  // *negative* offset.
+  cctz::time_zone tz = fixed_time_zone(-offset);
   std::clog.rdbuf(oldClogStreamBuf);
   if (stream.rdbuf()->in_avail()) {
     std::stringstream msg;

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -379,7 +379,7 @@ test_that("DATETIME2 precision (#790)", {
 test_that("DATETIMEOFFSET", {
   con <- test_con("SQLSERVER")
 
-  df <- data.frame(tz_char = rep("2025-05-10 19:35:03.123 +02:00", 3), tz = rep("2025-05-10 19:35:03.123 +02:00", 3))
+  df <- data.frame(tz_char = rep("2025-05-10 19:35:03.123 -02:00", 3), tz = rep("2025-05-10 19:35:03.123 -02:00", 3))
 
   tbl <- local_table(con, "test_datetimeoffset", df,
     field.types = list("tz_char" = "VARCHAR(50)", "tz" = "DATETIMEOFFSET"), overwrite = TRUE)


### PR DESCRIPTION
Closes #946 

In the previous release we introduced a SQL SERVER improvement where `DATETIMEOFFSET` data is automatically transformed into UTC and returned as `POSIXct` ( previously returned as strings containing the offset ).  As part of that transformation we use `cctz` to transform the specified offset into a timezone and in turn into `UTC` time.

As it turns out there are competing (and opposing) conventions for the direction of the offset:

* POSIX: positive offset denotes time zone west of Greenwich.
* ISO8601: positive offset denotes time zone east of Greenwich.

We coded the feature to keep with the `POSIX` convention.  However, I think it probably makes sense to convert to using ISO8601 since it is referenced in the[ Microsoft docs,](https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql?view=sql-server-ver17#supported-string-literal-formats-for-datetimeoffset) although the docs don't specifically mention the direction of the offset.

The way coded in this patch, we make a clean break and note it in the release notes.  Given that this is a breaking change, we could introduce a package option (`odbc.mssql.tz_direction`) or somesuch.  I am slightly biased  towards going with what's here since we've only had this code in for a few weeks/months, however can be swayed.