### PR TITLE
Fix MUSL CRAN check fail.

### DIFF
--- a/src/cctz/src/time_zone_info.cc
+++ b/src/cctz/src/time_zone_info.cc
@@ -67,7 +67,7 @@ std::string StrError(int errnum) {
   char buf[128];
 #if defined(_WIN32) || defined(_WIN64)
   if (int e = strerror_s(buf, sizeof buf, errnum))
-    strerror_s(buf, e);
+    strerror_s(buf, sizeof buf, e);
   return buf;
 #else
   return StrError<strerror_r>(errnum, buf, sizeof buf);


### PR DESCRIPTION
Should fix [CRAN check failure](https://raw.githubusercontent.com/bastistician/Rcheck/refs/heads/results/musl/issues/odbc.out) on Alpine linux/MUSL 

This patch is seen upstream: https://github.com/google/cctz/commit/8775f882d30fa25d5b142ca8a33b1049985aeffe

Related issues: https://github.com/r-dbi/odbc/issues/481, https://github.com/r-dbi/odbc/pull/400
~Untested currently, will see if I can get an Alpine linux container running.~

TODO:

- [x] Verify locally in an Alpine/Linux container.