### PR TITLE
Fixup/paws.common dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests:
     httr2,
     knitr,
     magrittr,
-    paws.common (>= 0.7.1),
+    paws.common,
     rmarkdown,
     RSQLite,
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests:
     httr2,
     knitr,
     magrittr,
-    paws.common,
+    paws.common (>= 0.7.1),
     rmarkdown,
     RSQLite,
     testthat (>= 3.0.0),

--- a/tests/testthat/test-driver-redshift.R
+++ b/tests/testthat/test-driver-redshift.R
@@ -6,6 +6,13 @@ test_that("the 'uid' and 'pwd' arguments suppress IAM auth", {
 })
 
 test_that("IAM credentials in environment variables are handled correctly", {
+  if(is_windows()) {
+    # paws.common binary tarball for windows 4.1
+    # is 0.5.x which does not have paws::locate_credentials
+    # exported.
+    # For exmaple, https://cran.rstudio.com/bin/windows/contrib/4.1/
+    skip_unless_r(">= 4.2")
+  }
   withr::local_envvar(
     AWS_ACCESS_KEY_ID = "access-key-id",
     AWS_SECRET_ACCESS_KEY = "secret-access-key",


### PR DESCRIPTION
This to help the windows/4.1 pipeline pass.

Our `driver-redshift` methods use `paws.common::locate_credentials` which is only exported in `paws.common >= 0.7.1`.  Our windows/4.1 pipeline is failing b/c CRAN mirrors carry a 4.1+windows/binary release 0.5.x.

Ideally, we would circumvent the binary releases by specifying the version dependency in `DESCRIPTION.Suggests`, however looks like `paws.common` doesn't (easily) build on Windows+4.1.  At first glance it looks like the package has an unstated requirement of `c++14` but Windows/4.1 builds with `c++11` by default. 