### PR TITLE
Use Snowflake config.toml/connection.toml files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Suggests:
     RSQLite,
     testthat (>= 3.0.0),
     tibble,
+    toml,
     withr
 LinkingTo: 
     Rcpp

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # odbc (development version)
 
+* Snowflake: Connection parameters can now be loaded from configuration files
+  (`~/.snowflake/connections.toml` or `~/.snowflake/config.toml`), following
+  the same conventions as the Snowflake Python connector. Requires the toml
+  package (#975).
+
 # odbc 1.6.4
 
 * Fix writing of [R] date/time values that have integer storage. (#952)

--- a/R/driver-snowflake.R
+++ b/R/driver-snowflake.R
@@ -134,13 +134,6 @@ setMethod("odbcDataType", "Snowflake",
 #' @param drv an object that inherits from [DBI::DBIDriver-class],
 #' or an existing [DBI::DBIConnection-class]
 #' object (in order to clone an existing connection).
-#' @param connection_name The name of a connection profile to load from
-#'   configuration files. If provided, connection parameters are loaded from
-#'   `~/.snowflake/connections.toml` (or the location specified by
-#'   `SNOWFLAKE_HOME`) and merged with any explicitly provided arguments.
-#'   Requires the \pkg{toml} package.
-#' @param connections_file_path Optional custom path to a `connections.toml`
-#'   file. If `NULL`, uses the default location within `SNOWFLAKE_HOME`.
 #' @param account A Snowflake [account
 #'   identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier),
 #'   e.g. `"testorg-test_account"`. If not provided and no `connection_name`
@@ -157,6 +150,13 @@ setMethod("odbcDataType", "Snowflake",
 #'   Specifying these options will disable ambient credential discovery and
 #'   config file loading (unless `connection_name` is also specified).
 #' @param ... Further arguments passed on to [`dbConnect()`].
+#' @param connection_name The name of a connection profile to load from
+#'   configuration files. If provided, connection parameters are loaded from
+#'   `~/.snowflake/connections.toml` (or the location specified by
+#'   `SNOWFLAKE_HOME`) and merged with any explicitly provided arguments.
+#'   Requires the \pkg{toml} package.
+#' @param connections_file_path Optional custom path to a `connections.toml`
+#'   file. If `NULL`, uses the default location within `SNOWFLAKE_HOME`.
 #'
 #' @returns An `OdbcConnection` object with an active connection to a Snowflake
 #'   account.
@@ -213,8 +213,6 @@ setClass("SnowflakeOdbcDriver", contains = "OdbcDriver")
 setMethod(
   "dbConnect", "SnowflakeOdbcDriver",
   function(drv,
-           connection_name = NULL,
-           connections_file_path = NULL,
            account = NULL,
            driver = NULL,
            warehouse = NULL,
@@ -222,7 +220,9 @@ setMethod(
            schema = NULL,
            uid = NULL,
            pwd = NULL,
-           ...) {
+           ...,
+           connection_name = NULL,
+           connections_file_path = NULL) {
     call <- caller_env()
     check_string(connection_name, allow_null = TRUE, call = call)
     check_string(connections_file_path, allow_null = TRUE, call = call)

--- a/R/driver-snowflake.R
+++ b/R/driver-snowflake.R
@@ -340,7 +340,12 @@ snowflake_args <- function(connection_name = NULL,
   )
 
   # 8. Merge auth into args, then apply final programmatic overrides
-  all <- utils::modifyList(c(args, auth), list(...))
+  # Remove uid/pwd/authenticator from args before merging with auth to avoid duplicates
+  # (auth may return these, and args already has them from resolved_params)
+  args$uid <- NULL
+  args$pwd <- NULL
+  args$authenticator <- NULL
+  all <- utils::modifyList(utils::modifyList(args, auth), list(...))
 
   # Set application value and respect the Snowflake Partner environment variable, if present.
   if (is.null(all$application)) {
@@ -458,7 +463,7 @@ snowflake_auth_args <- function(account,
       # allow for uid without pwd for alt auth (#817, #889)
       (!is.null(pwd) ||
        isTRUE(authenticator %in% c("externalbrowser", "SNOWFLAKE_JWT")))) {
-    return(list(uid = uid, pwd = pwd))
+    return(list(uid = uid, pwd = pwd, authenticator = authenticator))
   } else if (xor(is.null(uid), is.null(pwd))) {
     abort(
       c(

--- a/R/driver-snowflake.R
+++ b/R/driver-snowflake.R
@@ -686,15 +686,7 @@ parse_toml_string <- function(toml_string) {
 #' Check if toml package is installed
 #' @noRd
 check_toml_installed <- function() {
-  if (!rlang::is_installed("toml")) {
-    cli::cli_abort(
-      c(
-        "The {.pkg toml} package is required to load Snowflake configuration files.",
-        "i" = "Install it with {.code install.packages(\"toml\")}."
-      ),
-      call = quote(DBI::dbConnect())
-    )
-  }
+  rlang::check_installed("toml", "to load Snowflake configuration files")
 }
 
 #' Load and merge Snowflake configuration from files and environment variables

--- a/R/driver-snowflake.R
+++ b/R/driver-snowflake.R
@@ -251,6 +251,38 @@ setMethod(
   }
 )
 
+# Build connection arguments for Snowflake ODBC connections
+#
+# This function resolves and merges connection parameters from three sources
+# (in order of precedence, highest to lowest):
+# 1. Programmatic arguments passed directly to dbConnect()
+# 2. Connection parameters from Snowflake config files (connections.toml)
+# 3. Environment variables (SNOWFLAKE_ACCOUNT, only in programmatic mode)
+#
+# The function handles three connection resolution cases:
+# - Case 1: Named connection (connection_name specified) - loads from config,
+#   merges with programmatic args
+# - Case 2: Default connection (no programmatic params) - loads "default"
+#   connection from config, or uses default_connection_name from config.toml
+# - Case 3: Programmatic only (programmatic params provided, no connection_name) -
+#   skips config files entirely
+#
+# Authentication is delegated to snowflake_auth_args(), which handles various
+# auth methods including uid/pwd, externalbrowser, SNOWFLAKE_JWT, OAuth tokens
+# from Posit Connect, and Workbench-managed credentials.
+#
+# @param connection_name Name of connection to load from connections.toml
+# @param connections_file_path Optional path to connections.toml file
+# @param account Snowflake account identifier
+# @param driver ODBC driver name or path
+# @param warehouse Snowflake warehouse name
+# @param database Snowflake database name
+# @param schema Snowflake schema name
+# @param uid User ID for authentication
+# @param pwd Password for authentication
+# @param ... Additional connection parameters
+# @return Named list of connection arguments suitable for dbConnect(odbc(), ...)
+# @noRd
 snowflake_args <- function(connection_name = NULL,
                            connections_file_path = NULL,
                            account = NULL,

--- a/man/snowflake.Rd
+++ b/man/snowflake.Rd
@@ -11,8 +11,6 @@ snowflake()
 
 \S4method{dbConnect}{SnowflakeOdbcDriver}(
   drv,
-  connection_name = NULL,
-  connections_file_path = NULL,
   account = NULL,
   driver = NULL,
   warehouse = NULL,
@@ -20,22 +18,15 @@ snowflake()
   schema = NULL,
   uid = NULL,
   pwd = NULL,
-  ...
+  ...,
+  connection_name = NULL,
+  connections_file_path = NULL
 )
 }
 \arguments{
 \item{drv}{an object that inherits from \link[DBI:DBIDriver-class]{DBI::DBIDriver},
 or an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection}
 object (in order to clone an existing connection).}
-
-\item{connection_name}{The name of a connection profile to load from
-configuration files. If provided, connection parameters are loaded from
-\verb{~/.snowflake/connections.toml} (or the location specified by
-\code{SNOWFLAKE_HOME}) and merged with any explicitly provided arguments.
-Requires the \pkg{toml} package.}
-
-\item{connections_file_path}{Optional custom path to a \code{connections.toml}
-file. If \code{NULL}, uses the default location within \code{SNOWFLAKE_HOME}.}
 
 \item{account}{A Snowflake \href{https://docs.snowflake.com/en/user-guide/admin-account-identifier}{account identifier},
 e.g. \code{"testorg-test_account"}. If not provided and no \code{connection_name}
@@ -58,6 +49,15 @@ Specifying these options will disable ambient credential discovery and
 config file loading (unless \code{connection_name} is also specified).}
 
 \item{...}{Further arguments passed on to \code{\link[=dbConnect]{dbConnect()}}.}
+
+\item{connection_name}{The name of a connection profile to load from
+configuration files. If provided, connection parameters are loaded from
+\verb{~/.snowflake/connections.toml} (or the location specified by
+\code{SNOWFLAKE_HOME}) and merged with any explicitly provided arguments.
+Requires the \pkg{toml} package.}
+
+\item{connections_file_path}{Optional custom path to a \code{connections.toml}
+file. If \code{NULL}, uses the default location within \code{SNOWFLAKE_HOME}.}
 }
 \value{
 An \code{OdbcConnection} object with an active connection to a Snowflake

--- a/man/snowflake.Rd
+++ b/man/snowflake.Rd
@@ -11,7 +11,9 @@ snowflake()
 
 \S4method{dbConnect}{SnowflakeOdbcDriver}(
   drv,
-  account = Sys.getenv("SNOWFLAKE_ACCOUNT"),
+  connection_name = NULL,
+  connections_file_path = NULL,
+  account = NULL,
   driver = NULL,
   warehouse = NULL,
   database = NULL,
@@ -26,8 +28,18 @@ snowflake()
 or an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection}
 object (in order to clone an existing connection).}
 
+\item{connection_name}{The name of a connection profile to load from
+configuration files. If provided, connection parameters are loaded from
+\verb{~/.snowflake/connections.toml} (or the location specified by
+\code{SNOWFLAKE_HOME}) and merged with any explicitly provided arguments.
+Requires the \pkg{toml} package.}
+
+\item{connections_file_path}{Optional custom path to a \code{connections.toml}
+file. If \code{NULL}, uses the default location within \code{SNOWFLAKE_HOME}.}
+
 \item{account}{A Snowflake \href{https://docs.snowflake.com/en/user-guide/admin-account-identifier}{account identifier},
-e.g. \code{"testorg-test_account"}.}
+e.g. \code{"testorg-test_account"}. If not provided and no \code{connection_name}
+is specified, the \code{SNOWFLAKE_ACCOUNT} environment variable will be used.}
 
 \item{driver}{The name of the Snowflake ODBC driver, or \code{NULL} to use the
 default name.}
@@ -42,7 +54,8 @@ default.}
 default.}
 
 \item{uid, pwd}{Manually specify a username and password for authentication.
-Specifying these options will disable ambient credential discovery.}
+Specifying these options will disable ambient credential discovery and
+config file loading (unless \code{connection_name} is also specified).}
 
 \item{...}{Further arguments passed on to \code{\link[=dbConnect]{dbConnect()}}.}
 }
@@ -58,15 +71,49 @@ detects ambient OAuth credentials on platforms like Snowpark Container
 Services or Posit Workbench. It can also detect viewer-based
 credentials on Posit Connect if the \pkg{connectcreds} package is
 installed.
+\subsection{Configuration Files}{
+
+Connection parameters can be loaded from Snowflake configuration files
+(\verb{~/.snowflake/connections.toml} or \verb{~/.snowflake/config.toml}), following
+the same conventions as the Snowflake Python connector. This requires the
+\pkg{toml} package to be installed.
+
+Configuration files are loaded from \code{SNOWFLAKE_HOME} environment variable,
+\verb{~/.snowflake/} if it exists, or platform-specific defaults
+(\verb{~/Library/Application Support/snowflake/} on macOS,
+\verb{~/.config/snowflake/} on Linux).
+
+The \code{SNOWFLAKE_CONNECTIONS} environment variable can contain a full TOML
+document that overrides file-based connections. The
+\code{SNOWFLAKE_DEFAULT_CONNECTION_NAME} environment variable overrides the
+default connection name.
+
+On non-Windows platforms, configuration files are checked for secure
+permissions. Files writable by group or others will cause an error; files
+readable by others will generate a warning. Set
+\code{SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE=true} to suppress
+these checks.
 
 In addition, on macOS platforms, the \code{dbConnect} method will check and warn
 if it detects irregularities with how the driver is configured, unless the
 \code{odbc.no_config_override} environment variable is set.
 }
+}
 \examples{
 \dontrun{
 # Use ambient credentials.
 DBI::dbConnect(odbc::snowflake())
+
+# Load connection from config file (~/.snowflake/connections.toml)
+# Requires the toml package to be installed.
+DBI::dbConnect(odbc::snowflake(), connection_name = "prod")
+
+# Load connection and override specific parameters
+DBI::dbConnect(
+  odbc::snowflake(),
+  connection_name = "prod",
+  warehouse = "ADHOC_WH"
+)
 
 # Use browser-based SSO (if configured). Only works on desktop.
 DBI::dbConnect(

--- a/tests/testthat/_snaps/driver-snowflake.md
+++ b/tests/testthat/_snaps/driver-snowflake.md
@@ -4,7 +4,7 @@
       snowflake_args(driver = "driver")
     Condition
       Error in `DBI::dbConnect()`:
-      ! Default connection with name 'default' cannot be found.
+      ! Default connection "default" cannot be found.
       i No connections defined in configuration files.
 
 # both 'uid' and 'pwd' are required when present
@@ -60,7 +60,8 @@
       snowflake_args(connection_name = "staging", driver = "driver")
     Condition
       Error in `DBI::dbConnect()`:
-      ! Invalid connection_name 'staging', known ones are ['prod', 'dev']
+      ! Invalid `connection_name` "staging".
+      i Known connections: "prod" and "dev".
 
 # Missing default connection errors with known names
 
@@ -68,5 +69,6 @@
       snowflake_args(driver = "driver")
     Condition
       Error in `DBI::dbConnect()`:
-      ! Default connection with name 'default' cannot be found, known ones are ['prod']
+      ! Default connection "default" cannot be found.
+      i Known connection: "prod".
 

--- a/tests/testthat/_snaps/driver-snowflake.md
+++ b/tests/testthat/_snaps/driver-snowflake.md
@@ -4,8 +4,8 @@
       snowflake_args(driver = "driver")
     Condition
       Error in `DBI::dbConnect()`:
-      ! No Snowflake account ID provided.
-      i Either supply `account` argument or set env var `SNOWFLAKE_ACCOUNT`.
+      ! Default connection with name 'default' cannot be found.
+      i No connections defined in configuration files.
 
 # both 'uid' and 'pwd' are required when present
 
@@ -53,4 +53,20 @@
       Error in `DBI::dbConnect()`:
       ! Failed to detect ambient Snowflake credentials.
       i Supply `uid` and `pwd` to authenticate manually.
+
+# Invalid connection_name errors with known names
+
+    Code
+      snowflake_args(connection_name = "staging", driver = "driver")
+    Condition
+      Error in `DBI::dbConnect()`:
+      ! Invalid connection_name 'staging', known ones are ['prod', 'dev']
+
+# Missing default connection errors with known names
+
+    Code
+      snowflake_args(driver = "driver")
+    Condition
+      Error in `DBI::dbConnect()`:
+      ! Default connection with name 'default' cannot be found, known ones are ['prod']
 

--- a/tests/testthat/test-driver-snowflake.R
+++ b/tests/testthat/test-driver-snowflake.R
@@ -10,9 +10,7 @@ test_that("can connect to snowflake", {
 test_that("an account ID is required", {
   withr::local_envvar(SNOWFLAKE_ACCOUNT = "")
   # Create an empty config dir so we get a clean "no connections" error
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
   withr::local_envvar(SNOWFLAKE_HOME = config_dir)
   expect_snapshot(snowflake_args(driver = "driver"), error = TRUE)
 })
@@ -224,9 +222,7 @@ test_that("snowflake_config_dir() falls back to platform defaults on macOS", {
 test_that("load_snowflake_config() loads connections.toml correctly", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c(
@@ -257,9 +253,7 @@ test_that("load_snowflake_config() loads connections.toml correctly", {
 test_that("load_snowflake_config() loads config.toml correctly", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c(
@@ -283,9 +277,7 @@ test_that("load_snowflake_config() loads config.toml correctly", {
 test_that("load_snowflake_config() merges connections.toml over config.toml", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c(
@@ -321,9 +313,7 @@ test_that("load_snowflake_config() merges connections.toml over config.toml", {
 test_that("load_snowflake_config() handles missing files gracefully", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   config <- load_snowflake_config(config_dir)
 
@@ -341,9 +331,7 @@ user = "envuser"',
     SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE = "true"
   )
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c('[prod]', 'account = "fileaccount"'),
@@ -363,9 +351,7 @@ test_that("SNOWFLAKE_DEFAULT_CONNECTION_NAME env var overrides config file", {
     SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE = "true"
   )
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     'default_connection_name = "prod"',
@@ -377,12 +363,10 @@ test_that("SNOWFLAKE_DEFAULT_CONNECTION_NAME env var overrides config file", {
   expect_equal(config$default_connection_name, "staging")
 })
 
-test_that("Case 1: Named connection loads and merges with kwargs", {
+test_that("Named connection loads and merges with kwargs", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c(
@@ -449,9 +433,7 @@ test_that("Config file with user and authenticator (no password) works", {
 test_that("Config file authenticator is preserved in final args", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c(
@@ -475,12 +457,10 @@ test_that("Config file authenticator is preserved in final args", {
   expect_equal(args$uid, "testuser")
 })
 
-test_that("Case 2: Default connection loads when no args provided", {
+test_that("Default connection loads when no args provided", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c(
@@ -505,13 +485,11 @@ test_that("Case 2: Default connection loads when no args provided", {
   expect_equal(args$pwd, "defaultpwd")
 })
 
-test_that("Case 3: Programmatic params skip file loading", {
+test_that("Programmatic params skip file loading", {
   skip_if_not_installed("toml")
 
   # Create config files that should NOT be read
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c(
@@ -541,9 +519,7 @@ test_that("Case 3: Programmatic params skip file loading", {
 test_that("SNOWFLAKE_ACCOUNT env var only used in programmatic mode", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c(
@@ -561,11 +537,11 @@ test_that("SNOWFLAKE_ACCOUNT env var only used in programmatic mode", {
     SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE = "true"
   )
 
-  # Case 2: Should NOT use SNOWFLAKE_ACCOUNT env var
+  # Should NOT use SNOWFLAKE_ACCOUNT env var
   args <- snowflake_args(driver = "driver")
   expect_equal(args$account, "configaccount")
 
-  # Case 3: SHOULD use SNOWFLAKE_ACCOUNT env var as fallback
+  # SHOULD use SNOWFLAKE_ACCOUNT env var as fallback
   args2 <- snowflake_args(driver = "driver", uid = "user", pwd = "password")
   expect_equal(args2$account, "envaccount")
 })
@@ -573,9 +549,7 @@ test_that("SNOWFLAKE_ACCOUNT env var only used in programmatic mode", {
 test_that("Invalid connection_name errors with known names", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c('[prod]', 'account = "test"', '', '[dev]', 'account = "test"'),
@@ -596,9 +570,7 @@ test_that("Invalid connection_name errors with known names", {
 test_that("Missing default connection errors with known names", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   writeLines(
     c('[prod]', 'account = "test"', 'user = "test"', 'password = "test"'),
@@ -734,24 +706,10 @@ test_that("check_toml_file_permissions() passes with correct permissions (0600)"
   expect_no_warning(check_toml_file_permissions(config_file))
 })
 
-test_that("check_toml_installed() errors when toml not installed", {
-  local_mocked_bindings(
-    is_installed = function(pkg) FALSE,
-    .package = "rlang"
-  )
-
-  expect_error(
-    check_toml_installed(),
-    "toml.*required"
-  )
-})
-
 test_that("SNOWFLAKE_CONNECTIONS can use default_connection_name from config.toml", {
   skip_if_not_installed("toml")
 
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   # config.toml sets default_connection_name to "myconn"
   writeLines(
@@ -774,9 +732,7 @@ test_that("SNOWFLAKE_CONNECTIONS can use default_connection_name from config.tom
 })
 
 test_that("Missing toml errors when config files exist (Case 2)", {
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   # Create a connections.toml file
   writeLines(
@@ -791,11 +747,12 @@ test_that("Missing toml errors when config files exist (Case 2)", {
 
   # Mock toml as not installed
   local_mocked_bindings(
-    is_installed = function(pkg) pkg != "toml",
-    .package = "rlang"
+    check_toml_installed = function() {
+      rlang::abort("The toml package is required to load Snowflake configuration files.")
+    }
   )
 
-  # Case 2: no programmatic params, should try to load config and error
+  # No programmatic params, should try to load config and error
   expect_error(
     snowflake_args(driver = "driver"),
     "toml.*required"
@@ -810,8 +767,9 @@ test_that("Missing toml errors when SNOWFLAKE_CONNECTIONS is set", {
 
   # Mock toml as not installed
   local_mocked_bindings(
-    is_installed = function(pkg) pkg != "toml",
-    .package = "rlang"
+    check_toml_installed = function() {
+      rlang::abort("The toml package is required to load Snowflake configuration files.")
+    }
   )
 
   # Should error because we need toml to parse SNOWFLAKE_CONNECTIONS
@@ -822,9 +780,7 @@ test_that("Missing toml errors when SNOWFLAKE_CONNECTIONS is set", {
 })
 
 test_that("Missing toml does NOT error when programmatic params provided (Case 3)", {
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   # Create a connections.toml file (should be ignored in Case 3)
   writeLines(
@@ -837,13 +793,14 @@ test_that("Missing toml does NOT error when programmatic params provided (Case 3
     SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE = "true"
   )
 
-  # Mock toml as not installed
+  # Mock toml as not installed - should not matter because we have programmatic params
   local_mocked_bindings(
-    is_installed = function(pkg) pkg != "toml",
-    .package = "rlang"
+    check_toml_installed = function() {
+      rlang::abort("The toml package is required to load Snowflake configuration files.")
+    }
   )
 
-  # Case 3: has programmatic params, should NOT try to load config
+  # Has programmatic params, should NOT try to load config
   args <- snowflake_args(
     account = "programmatic",
     driver = "driver",
@@ -856,9 +813,7 @@ test_that("Missing toml does NOT error when programmatic params provided (Case 3
 })
 
 test_that("Missing toml does NOT error when no config files and no env var", {
-  config_dir <- tempfile()
-  dir.create(config_dir)
-  withr::defer(unlink(config_dir, recursive = TRUE))
+  config_dir <- withr::local_tempdir()
 
   # Empty config dir - no toml files
 


### PR DESCRIPTION
~**Vibe coded; just for discussion purposes for now**~ Extremely carefully reviewed by @jcheng5, except unit tests (life is too short)

---

Add support for loading connection parameters from TOML config files (~/.snowflake/connections.toml and config.toml) following the Python Snowflake connector conventions.

New features:
- `connection_name` parameter to load a named connection profile
- `connections_file_path` parameter to specify custom config location
- Support for SNOWFLAKE_CONNECTIONS env var (full TOML override)
- Support for SNOWFLAKE_DEFAULT_CONNECTION_NAME env var
- File permission security checks (error on writable, warn on readable)
- Graceful fallback when toml package not installed

Connection resolution:
- Case 1: connection_name provided → load and merge with kwargs
- Case 2: No args → load default connection from config
- Case 3: Programmatic params → use params only, skip config loading

SNOWFLAKE_ACCOUNT env var is only used in Case 3 (programmatic mode), not when loading from config files.

Requires the toml package (Suggests) for config file parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)