### PR TITLE
configure: CXX11 and CXX1X no longer supported

### DIFF
--- a/configure
+++ b/configure
@@ -53,11 +53,7 @@ else
 fi
 
 # Find compiler
-if "${R_HOME}"/bin/R CMD config CXX11 > /dev/null; then
-  CXX11="`"${R_HOME}"/bin/R CMD config CXX11` -E"
-else
-  CXX11="`"${R_HOME}"/bin/R CMD config CXX1X` -E"
-fi
+CXX="`"${R_HOME}"/bin/R CMD config CXX` -E"
 
 CXXFLAGS=`"${R_HOME}"/bin/R CMD config CXXFLAGS`
 CPPFLAGS=`"${R_HOME}"/bin/R CMD config CPPFLAGS`
@@ -67,7 +63,7 @@ echo "PKG_CFLAGS=$PKG_CFLAGS"
 echo "PKG_LIBS=$PKG_LIBS"
 
 # Test for odbc
-echo "#include $PKG_TEST_HEADER" | ${CXX11} ${PKG_CFLAGS} ${CPPFLAGS} ${CXXFLAGS} -xc++ - > /dev/null
+echo "#include $PKG_TEST_HEADER" | ${CXX} ${PKG_CFLAGS} ${CPPFLAGS} ${CXXFLAGS} -xc++ - > /dev/null
 if [ $? -ne 0 ]; then
   echo "------------------------- ANTICONF ERROR ---------------------------"
   echo "Configuration failed because $PKG_CONFIG_NAME was not found. Try installing:"


### PR DESCRIPTION
Follow up on BDR email.

I think this is straightforward - at this point, in all supported versions of [R] the default compiler is C++11 capable.  Therefore it is OK to use the "CXX" variable.