### PR TITLE
Configure fallback path for Linux on ARM64

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -368,6 +368,7 @@ locate_install_unixodbc <- function() {
     "/lib",
     "/usr/local/lib",
     "/usr/lib/x86_64-linux-gnu",
+    "/usr/lib/aarch64-linux-gnu",
     "/opt/homebrew/lib",
     "/opt/homebrew/etc",
     "/opt/homebrew/opt/unixodbc/lib",


### PR DESCRIPTION
Only relevant for systems without `pkg-config` .