### PR TITLE
Databricks native query improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # odbc (development version)
 
+* Databricks: Improve performance when `useNativeQuery`
+  connection attribute is set to `true` (#998).
+
 * SQL Server: Make it possible to write `POSIXct` data
   to `DATETIMEOFFSET` targets (#985).
 

--- a/R/dbi-connection.R
+++ b/R/dbi-connection.R
@@ -8,7 +8,8 @@ setClass(
     ptr = "externalptr",
     quote = "character",
     info = "ANY",
-    encoding = "character"
+    encoding = "character",
+    connectionString = "list"
   )
 )
 

--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -31,8 +31,10 @@ NULL
 #'   under `Advanced Options > JDBC/ODBC` in the Databricks UI. For SQL
 #'   warehouses, this is found under `Connection Details` instead.
 #' @param useNativeQuery Suppress the driver's conversion from ANSI SQL 92 to
-#'   HiveSQL? The default (`TRUE`), gives greater performance but means that
-#'   paramterised queries (and hence `dbWriteTable()`) do not work.
+#'   HiveSQL.  When set to true, we also set the following related flags:
+#'   `EnableNativeParameterizedQuery`, and `PopulateParametersForNativeQuery`.
+#'   The default (`TRUE`), gives greater performance but could cause issues
+#'   with paramterised queries (and hence `dbWriteTable()`).
 #' @param workspace The URL of a Databricks workspace, e.g.
 #'   `"https://example.cloud.databricks.com"`.
 #' @param driver The name of the Databricks ODBC driver, or `NULL` to use the
@@ -149,18 +151,27 @@ databricks_args <- function(httpPath,
 }
 
 databricks_default_args <- function(driver, host, httpPath, useNativeQuery) {
-  list(
+  ret <- list(
     driver = driver %||% databricks_default_driver(),
     host = host,
     httpPath = httpPath,
     thriftTransport = 2,
     userAgentEntry = databricks_user_agent(),
-    useNativeQuery = as.integer(useNativeQuery),
     # Connections to Databricks are always over HTTPS.
     port = 443,
     protocol = "https",
     ssl = 1
   )
+
+  nativeQueryArgs <- list(useNativeQuery = as.integer(useNativeQuery))
+  if (useNativeQuery) {
+    # Per driver documentation, when native query is enabled, the additional two flags help
+    # with properly handling parametrized queries
+    nativeQueryArgs <- c(nativeQueryArgs, EnableNativeParameterizedQuery = 1, PopulateParametersForNativeQuery = 1)
+  }
+
+  ret <- c(ret, nativeQueryArgs)
+  ret
 }
 
 

--- a/R/odbc-connection.R
+++ b/R/odbc-connection.R
@@ -75,19 +75,9 @@ OdbcConnection <- function(
     ptr = ptr,
     quote = quote,
     info = info,
-    encoding = encoding
+    encoding = encoding,
+    connectionString = decompose_connection_string(connection_string)
   )
-}
-
-build_connection_string <- function(args = list(), string = NULL) {
-
-  args_string <- paste(names(args), args, sep = "=", collapse = ";")
-
-  if (!is.null(string) && !grepl(";$", string) && length(args) > 0) {
-    string <- paste0(string, ";")
-  }
-
-  paste0(string, args_string)
 }
 
 #' Quote special character when connecting

--- a/R/utils.R
+++ b/R/utils.R
@@ -570,3 +570,70 @@ find_default_driver <- function(paths, fallbacks, label, call = caller_env()) {
     call = call
   )
 }
+
+#' Finalize a connection string by appending a list of arguments to an optional
+#' starting connection string.
+#'
+#' @description
+#' Arguments are expected in the formed of a named list (k1 = v1, k2 = v2),
+#' and are appended as key-value pairs:
+#' starting_string;k1=v1;k2=v2
+#'
+#' @param args A named list of arguments to append to connection string
+#' @param string An initial / starting connection string
+#' @return string A finalized connection string
+build_connection_string <- function(args = list(), string = NULL) {
+
+  args_string <- paste(names(args), args, sep = "=", collapse = ";")
+
+  if (!is.null(string) && !grepl(";$", string) && length(args) > 0) {
+    string <- paste0(string, ";")
+  }
+
+  paste0(string, args_string)
+}
+
+#' Decompose a connection string into a named list.
+#'
+#' @description
+#' This method essentially reverses `build_connection_string`,
+#' with the addition that we attempt to scrub out any
+#' sensitive key/value pairs when we return to the caller.
+#'
+#' @param string A connection string.  Expected format is
+#'               `k1=v1;k2=v2;k3=v3`
+#' @return list A named list (k1 = v1, k2 = v2, ...)
+decompose_connection_string <- function(string) {
+
+  res_pairs <- strsplit(string, ";", fixed = TRUE)[[1]]
+  res_key_value <- strsplit(res_pairs, "=", fixed = TRUE)
+  values <- lapply(res_key_value, FUN = function(x) trimws(x[2]) )
+  # Remove enclosing quotation marks around value
+  # we may have put them there using odbc::quote_value
+  values <- lapply(values, FUN = function(x) {
+      x <-gsub("(^')(.*)('$)", "\\2", x)
+      gsub("(^\")(.*)(\"$)", "\\2", x)
+  })
+  nms <- sapply(res_key_value, FUN = function(x) x[1])
+  names(values) <- trimws(nms)
+  return(sanitize_connection_string(values))
+}
+
+#' Sanitize a named list representing a connection string
+#' (see `decompose_connection_string`) by scrubbing out
+#' values belonging to keys we identify as potentially
+#' carrying authentication information.
+#'
+#' @description
+#' Scrubs out pre-set vector of key patterns.
+#'
+#' @param lst A named list representing contents of
+#'            connection string.
+#' @return A named list (k1 = v1, k2 = v2, ...), much like
+#'         input argument, with some values potentially filtered out.
+sanitize_connection_string <- function(lst) {
+  EXCLUDE_PATTERNS <- c("*PWD*", "*PASS*", "*TOKEN*")
+
+  regex <- paste(EXCLUDE_PATTERNS, tolower(EXCLUDE_PATTERNS), collapse = "|", sep = "|")
+  return(lst[!grepl(regex, names(lst), fixed = FALSE)])
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -582,6 +582,7 @@ find_default_driver <- function(paths, fallbacks, label, call = caller_env()) {
 #' @param args A named list of arguments to append to connection string
 #' @param string An initial / starting connection string
 #' @return string A finalized connection string
+#' @noRd
 build_connection_string <- function(args = list(), string = NULL) {
 
   args_string <- paste(names(args), args, sep = "=", collapse = ";")
@@ -603,11 +604,14 @@ build_connection_string <- function(args = list(), string = NULL) {
 #' @param string A connection string.  Expected format is
 #'               `k1=v1;k2=v2;k3=v3`
 #' @return list A named list (k1 = v1, k2 = v2, ...)
+#' @noRd
 decompose_connection_string <- function(string) {
 
   res_pairs <- strsplit(string, ";", fixed = TRUE)[[1]]
   res_key_value <- strsplit(res_pairs, "=", fixed = TRUE)
-  values <- lapply(res_key_value, FUN = function(x) trimws(x[2]) )
+  res_key_value <- Filter(function(x) length(x) == 2 && nchar(x[1]),
+                          res_key_value)
+  values <- lapply(res_key_value, FUN = function(x) trimws(x[2]))
   # Remove enclosing quotation marks around value
   # we may have put them there using odbc::quote_value
   values <- lapply(values, FUN = function(x) {
@@ -631,6 +635,7 @@ decompose_connection_string <- function(string) {
 #'            connection string.
 #' @return A named list (k1 = v1, k2 = v2, ...), much like
 #'         input argument, with some values potentially filtered out.
+#' @noRd
 sanitize_connection_string <- function(lst) {
   EXCLUDE_PATTERNS <- c("*PWD*", "*PASS*", "*TOKEN*")
 

--- a/tests/testthat/test-odbc-connection.R
+++ b/tests/testthat/test-odbc-connection.R
@@ -1,18 +1,4 @@
 
-# build_connection_string -------------------------------------------------
-
-test_that("handles simple inputs", {
-  expect_equal(build_connection_string(), "")
-  expect_equal(build_connection_string(list(foo = "1")), "foo=1")
-  expect_equal(build_connection_string(list(foo = "1", bar = "2")), "foo=1;bar=2")
-})
-
-test_that("combines with existing .connection string", {
-  expect_equal(build_connection_string(string = "x=1"), "x=1")
-  expect_equal(build_connection_string(list(foo = "1"), "x=1"), "x=1;foo=1")
-  expect_equal(build_connection_string(list(foo = "1"), "x=1;"), "x=1;foo=1")
-})
-
 test_that("errors if unnamed arguments", {
   expect_snapshot(check_args(list(1, 2, 3)), error = TRUE)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -383,3 +383,34 @@ test_that("configure_unixodbc_simba() writes reasonable entries", {
     action = "warn"
   ))
 })
+
+# Connection string helpers: build_connection_string,
+# decompose_connection_string, sanitize_connection_string
+
+test_that("handles simple inputs", {
+  expect_equal(build_connection_string(), "")
+  expect_equal(build_connection_string(list(foo = "1")), "foo=1")
+  expect_equal(build_connection_string(list(foo = "1", bar = "2")), "foo=1;bar=2")
+})
+
+test_that("combines with existing .connection string", {
+  expect_equal(build_connection_string(string = "x=1"), "x=1")
+  expect_equal(build_connection_string(list(foo = "1"), "x=1"), "x=1;foo=1")
+  expect_equal(build_connection_string(list(foo = "1"), "x=1;"), "x=1;foo=1")
+})
+
+test_that("Handles connection string as expected", {
+  conn_string <- build_connection_string(list(dsn = "abc",
+    k1 = quote_value("Quoted Value"),
+    k2 = quote_value("Quated value with a ' character")))
+  expect_equal(decompose_connection_string(conn_string), list(dsn = "abc",
+    k1 = "Quoted Value", k2 = "Quated value with a ' character"))
+})
+
+test_that("Sanitize filters out auth keys", {
+  lst <- list(dsn = "abc", useNativeQuery = "def", pwd = "p", PWD = "P",
+    password = "pass", PASSWORD = "PASSWORD", token = "token", TOKEN = "TOKEN",
+    MYPWD = "mywd")
+  expect_equal(sanitize_connection_string(lst), list(dsn = "abc",
+    useNativeQuery = "def"))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -405,6 +405,25 @@ test_that("Handles connection string as expected", {
     k2 = quote_value("Quated value with a ' character")))
   expect_equal(decompose_connection_string(conn_string), list(dsn = "abc",
     k1 = "Quoted Value", k2 = "Quated value with a ' character"))
+  # Robust to ending with semi-column
+  expect_equal(decompose_connection_string("abc=1;def=2;"), list(abc = "1",
+    def = "2"))
+  # Robust to starting with semi-column
+  expect_equal(decompose_connection_string(";abc=1;def=2"), list(abc = "1",
+    def = "2"))
+  # Robust to double semi-column
+  expect_equal(decompose_connection_string("abc=1;;def=2"), list(abc = "1",
+    def = "2"))
+  # Key-value entries with missing key are filtered out
+  expect_equal(decompose_connection_string("abc=1;def=2;=3"), list(abc = "1",
+    def = "2"))
+  # Key-value entries with missing value are filtered out
+  expect_equal(decompose_connection_string("abc=1;def=2;ghi="), list(abc = "1",
+    def = "2"))
+  # Connection string segments that are not formatted as key-value
+  # pairs are filtered out
+  expect_equal(decompose_connection_string("abc=1;def=2;ghi"), list(abc = "1",
+    def = "2"))
 })
 
 test_that("Sanitize filters out auth keys", {


### PR DESCRIPTION
An attempt to tackle two issues RE: databricks connections:

* Support for parametrized queries when "useNativeQuery" flag is set to TRUE.  Recall, we have defaulted this to `true` (and in recent driver versions, vendor is defaulting it to true as well) because performance is better.  However, when enabled, parametrized queries don't work, including calls to `dbWriteTable` (implemented as a parametrized write).  Recent driver versions (Insight now provides both the PRO drivers as well as the OEM/Databricks driver) support additional flags to support parametrized queries when `useNativeQuery` is enabled.  Now, when we detect that `useNativeQuery` has been set to true, we also automatically enable the additional flags in an attempt to have the best of both worlds: performant data retrievals, as well as support for parametrized queries (and writing).
* Attempt to address #926 by decomposing the connection string and providing the key-value entries in a new slot of the connection object.

Closes #926 
