### PR TITLE
Use the 'snowflakeauth' package for odbc::snowflake()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Suggests:
     paws.common,
     rmarkdown,
     RSQLite,
+    snowflakeauth,
     testthat (>= 3.0.0),
     tibble,
     withr

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,13 @@
 * odbcConnectionColumns(), odbcConnectionIcon(), and odbcConnectionActions() are now fully deprecated.
   Use DBI::dbListFields() instead of odbcConnectionColumns() (#699).
 
+* `odbc::snowflake()` now uses the `snowflakeauth` package to resolve connection
+  parameters from Snowflake `connections.toml` and `config.toml` files under the
+  hood, which improves support for non-OAuth authenticators (including
+  "externalbrowser" authentication), adds support for the `host` field, allows
+  multiple named connections (via the new `connection_name` argument), and
+  generally improves compatibility with the Snowflake CLI and Python ecosystem.
+
 # odbc 1.6.4
 
 * Fix writing of [R] date/time values that have integer storage. (#952)

--- a/R/driver-snowflake.R
+++ b/R/driver-snowflake.R
@@ -99,10 +99,11 @@ setMethod("odbcDataType", "Snowflake",
 #' driver](https://docs.snowflake.com/en/developer-guide/odbc/odbc).
 #'
 #' In particular, the custom `dbConnect()` method for the Snowflake ODBC driver
-#' detects ambient OAuth credentials on platforms like Snowpark Container
-#' Services or Posit Workbench. It can also detect viewer-based
-#' credentials on Posit Connect if the \pkg{connectcreds} package is
-#' installed.
+#' supports the `connections.toml` and `config.toml` files used by the Snowflake
+#' Connector for Python and the Snowflake CLI via the \pkg{snowflakeauth}
+#' package. It also detects ambient OAuth credentials on platforms like Snowpark
+#' Container Services or Posit Workbench. Finally, it can detect viewer-based
+#' credentials on Posit Connect if the \pkg{connectcreds} package is installed.
 #'
 #' In addition, on macOS platforms, the `dbConnect` method will check and warn
 #' if it detects irregularities with how the driver is configured, unless the
@@ -124,6 +125,8 @@ setMethod("odbcDataType", "Snowflake",
 #'   default.
 #' @param uid,pwd Manually specify a username and password for authentication.
 #'   Specifying these options will disable ambient credential discovery.
+#' @param connection_name The name of a connection defined in your Snowflake
+#'   `connections.toml` file, or `NULL` to use the default connection.
 #' @param ... Further arguments passed on to [`dbConnect()`].
 #'
 #' @returns An `OdbcConnection` object with an active connection to a Snowflake
@@ -148,6 +151,9 @@ setMethod("odbcDataType", "Snowflake",
 #'   uid = "me",
 #'   pwd = rstudioapi::askForPassword()
 #' )
+#'
+#' # Use a named connection from a connections.toml file.
+#' DBI::dbConnect(odbc::snowflake(), connection_name = "test")
 #'
 #' # Use credentials from the viewer (when possible) in a Shiny app
 #' # deployed to Posit Connect.
@@ -177,6 +183,7 @@ setMethod(
            schema = NULL,
            uid = NULL,
            pwd = NULL,
+           connection_name = NULL,
            ...) {
     call <- caller_env()
     check_string(account, call = call)
@@ -185,6 +192,7 @@ setMethod(
     check_string(database, allow_null = TRUE, call = call)
     check_string(uid, allow_null = TRUE, call = call)
     check_string(pwd, allow_null = TRUE, call = call)
+    check_string(connection_name, allow_null = TRUE, call = call)
     args <- snowflake_args(
       account = account,
       driver = driver,
@@ -193,6 +201,7 @@ setMethod(
       schema = schema,
       uid = uid,
       pwd = pwd,
+      connection_name = connection_name,
       ...
     )
     # Perform some sanity checks on MacOS
@@ -205,15 +214,25 @@ setMethod(
 snowflake_args <- function(account = Sys.getenv("SNOWFLAKE_ACCOUNT"),
                            driver = NULL,
                            ...) {
+  auth <- snowflake_auth_args(account, ...)
+  host <- auth$.host
+  auth$.host <- NULL
+  if (!is.null(auth$.account)) {
+    account <- auth$.account
+  }
+  auth$.account <- NULL
+
   args <- list(
     driver = driver %||% snowflake_default_driver(),
     account = account,
-    server = snowflake_server(account),
+    server = snowflake_server(account, host = host),
     # Connections to Snowflake are always over HTTPS.
     port = 443
   )
-  auth <- snowflake_auth_args(account, ...)
-  all <- utils::modifyList(c(args, auth), list(...))
+  dots <- list(...)
+  dots$connection_name <- NULL
+  dots <- compact(dots)
+  all <- utils::modifyList(c(args, auth), dots)
 
   # Set application value and respect the Snowflake Partner environment variable, if present.
   if (is.null(all$application)) {
@@ -301,7 +320,10 @@ snowflake_simba_config <- function(driver) {
   ))
 }
 
-snowflake_server <- function(account) {
+snowflake_server <- function(account, host = NULL) {
+  if (!is.null(host) && nzchar(host)) {
+    return(host)
+  }
   if (nchar(account) == 0) {
     abort(
       c(
@@ -318,6 +340,7 @@ snowflake_auth_args <- function(account,
                                 uid = NULL,
                                 pwd = NULL,
                                 authenticator = NULL,
+                                connection_name = NULL,
                                 ...) {
   check_string(authenticator, allow_null = TRUE)
   # Detect viewer-based credentials from Posit Connect.
@@ -347,48 +370,84 @@ snowflake_auth_args <- function(account,
     return(list())
   }
 
-  # Check for Workbench-provided credentials.
-  sf_home <- Sys.getenv("SNOWFLAKE_HOME")
-  if (grepl("posit-workbench", sf_home, fixed = TRUE)) {
-    token <- workbench_snowflake_token(account, sf_home)
-    if (!is.null(token)) {
-      return(list(authenticator = "oauth", token = token))
-    }
+  check_installed("snowflakeauth")
+  sf_args <- list(name = connection_name)
+  dots <- list(...)
+  sf_params <- c(
+    "user", "role", "schema", "database", "warehouse", "authenticator",
+    "private_key", "private_key_file", "private_key_path",
+    "private_key_file_pwd", "token", "token_file_path", "password", "host"
+  )
+  dots <- compact(dots)
+  sf_args <- c(sf_args, dots[intersect(names(dots), sf_params)])
+  if (file.exists("/snowflake/session/token") &&
+      is.null(sf_args$token_file_path) &&
+      is.null(sf_args$token)) {
+    sf_args$token_file_path <- "/snowflake/session/token"
   }
-
-  # Check for the default token mounted when running in Snowpark Container
-  # Services.
-  if (file.exists("/snowflake/session/token")) {
-    return(list(
-      authenticator = "oauth",
-      token = readLines("/snowflake/session/token", warn = FALSE)
-    ))
+  # Don't pass `account` so we can compare it to what snowflakeauth resolves.
+  conn <- inject(snowflakeauth::snowflake_connection(!!!sf_args))
+  if (is.null(connection_name) &&
+      nzchar(account) && !is.null(conn$account) &&
+      !identical(account, conn$account)) {
+    cli::cli_abort(
+      c(
+        "Snowflake account mismatch: requested {.val {account}} but
+         connection {.val {conn$name %||% 'default'}} resolved
+         {.val {conn$account}}.",
+        "i" = "Check your {.file connections.toml} or pass the correct
+              {.arg account}."
+      ),
+      call = quote(DBI::dbConnect())
+    )
   }
-
-  list()
+  snowflake_connection_to_odbc_args(conn)
 }
 
-# Reads Posit Workbench-managed Snowflake credentials from a
-# $SNOWFLAKE_HOME/connections.toml file, as used by the Snowflake Connector for
-# Python implementation. The file will look as follows:
-#
-# [workbench]
-# account = "account-id"
-# token = "token"
-# authenticator = "oauth"
-workbench_snowflake_token <- function(account, sf_home) {
-  cfg <- readLines(file.path(sf_home, "connections.toml"))
-  # We don't attempt a full parse of the TOML syntax, instead relying on the
-  # fact that this file will always contain only one section.
-  if (!any(grepl(account, cfg, fixed = TRUE))) {
-    # The configuration doesn't actually apply to this account.
-    return(NULL)
+snowflake_connection_to_odbc_args <- function(conn) {
+  args <- list()
+
+  if (!is.null(conn$user)) {
+    args$uid <- conn$user
   }
-  line <- grepl("token = ", cfg, fixed = TRUE)
-  token <- gsub("token = ", "", cfg[line])
-  if (nchar(token) == 0) {
-    return(NULL)
+  if (!is.null(conn$password)) {
+    args$pwd <- unclass(conn$password)
   }
-  # Drop enclosing quotes.
-  gsub("\"", "", token)
+  if (!is.null(conn$token)) {
+    args$token <- unclass(conn$token)
+  }
+  if (!is.null(conn$token_file_path)) {
+    args$token_file_path <- conn$token_file_path
+  }
+  if (!is.null(conn$authenticator) && conn$authenticator != "snowflake") {
+    args$authenticator <- conn$authenticator
+  }
+
+  priv_key <- conn$private_key_file %||%
+    conn$private_key %||%
+    conn$private_key_path
+  if (!is.null(priv_key)) {
+    args$priv_key_file <- priv_key
+  }
+  if (!is.null(conn$private_key_file_pwd)) {
+    args$priv_key_file_pwd <- unclass(conn$private_key_file_pwd)
+  }
+
+  if (!is.null(conn$warehouse)) args$warehouse <- conn$warehouse
+  if (!is.null(conn$database)) args$database <- conn$database
+  if (!is.null(conn$schema)) args$schema <- conn$schema
+  if (!is.null(conn$role)) args$role <- conn$role
+  if (!is.null(conn$workload_identity_provider)) {
+    args$workload_identity_provider <- conn$workload_identity_provider
+  }
+
+  # Pass non-ODBC fields for snowflake_args() to use.
+  if (!is.null(conn$account) && nzchar(conn$account)) {
+    args$.account <- conn$account
+  }
+  if (!is.null(conn$host) && nzchar(conn$host)) {
+    args$.host <- conn$host
+  }
+
+  args
 }

--- a/man/snowflake.Rd
+++ b/man/snowflake.Rd
@@ -18,6 +18,7 @@ snowflake()
   schema = NULL,
   uid = NULL,
   pwd = NULL,
+  connection_name = NULL,
   ...
 )
 }
@@ -44,6 +45,9 @@ default.}
 \item{uid, pwd}{Manually specify a username and password for authentication.
 Specifying these options will disable ambient credential discovery.}
 
+\item{connection_name}{The name of a connection defined in your Snowflake
+\code{connections.toml} file, or \code{NULL} to use the default connection.}
+
 \item{...}{Further arguments passed on to \code{\link[=dbConnect]{dbConnect()}}.}
 }
 \value{
@@ -54,10 +58,11 @@ account.
 Connect to a Snowflake account via the \href{https://docs.snowflake.com/en/developer-guide/odbc/odbc}{Snowflake ODBC driver}.
 
 In particular, the custom \code{dbConnect()} method for the Snowflake ODBC driver
-detects ambient OAuth credentials on platforms like Snowpark Container
-Services or Posit Workbench. It can also detect viewer-based
-credentials on Posit Connect if the \pkg{connectcreds} package is
-installed.
+supports the \code{connections.toml} and \code{config.toml} files used by the Snowflake
+Connector for Python and the Snowflake CLI via the \pkg{snowflakeauth}
+package. It also detects ambient OAuth credentials on platforms like Snowpark
+Container Services or Posit Workbench. Finally, it can detect viewer-based
+credentials on Posit Connect if the \pkg{connectcreds} package is installed.
 
 In addition, on macOS platforms, the \code{dbConnect} method will check and warn
 if it detects irregularities with how the driver is configured, unless the
@@ -82,6 +87,9 @@ DBI::dbConnect(
   uid = "me",
   pwd = rstudioapi::askForPassword()
 )
+
+# Use a named connection from a connections.toml file.
+DBI::dbConnect(odbc::snowflake(), connection_name = "test")
 
 # Use credentials from the viewer (when possible) in a Shiny app
 # deployed to Posit Connect.

--- a/tests/testthat/_snaps/driver-snowflake.md
+++ b/tests/testthat/_snaps/driver-snowflake.md
@@ -3,9 +3,9 @@
     Code
       snowflake_args(driver = "driver")
     Condition
-      Error in `DBI::dbConnect()`:
-      ! No Snowflake account ID provided.
-      i Either supply `account` argument or set env var `SNOWFLAKE_ACCOUNT`.
+      Error in `snowflakeauth::snowflake_connection()`:
+      ! An `account` parameter is required when '<tmp>/connections.toml' is missing or empty.
+      i Pass `account` or define a [default] section with an account field in '<tmp>/connections.toml'.
 
 # both 'uid' and 'pwd' are required when present
 
@@ -45,12 +45,12 @@
       ! Failed to automatically find the Snowflake ODBC driver.
       i Set `driver` to known driver name or path.
 
-# Workbench-managed credentials are ignored for other accounts
+# Workbench-managed credentials are rejected for other accounts
 
     Code
       snowflake_args(account = "testorg-test_account", driver = "driver")
     Condition
       Error in `DBI::dbConnect()`:
-      ! Failed to detect ambient Snowflake credentials.
-      i Supply `uid` and `pwd` to authenticate manually.
+      ! Snowflake account mismatch: requested "testorg-test_account" but connection "workbench" resolved "nonmatching".
+      i Check your 'connections.toml' or pass the correct `account`.
 

--- a/tests/testthat/test-driver-snowflake.R
+++ b/tests/testthat/test-driver-snowflake.R
@@ -8,8 +8,16 @@ test_that("can connect to snowflake", {
 })
 
 test_that("an account ID is required", {
-  withr::local_envvar(SNOWFLAKE_ACCOUNT = "")
-  expect_snapshot(snowflake_args(driver = "driver"), error = TRUE)
+  sf_home <- tempfile()
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "",
+    SNOWFLAKE_HOME = sf_home
+  )
+  expect_snapshot(
+    snowflake_args(driver = "driver"),
+    error = TRUE,
+    transform = function(x) gsub(sf_home, "<tmp>", x, fixed = TRUE)
+  )
 })
 
 test_that("environment variables are handled correctly", {
@@ -160,6 +168,7 @@ test_that("Workbench-managed credentials are detected correctly", {
   )
   withr::local_envvar(
     SNOWFLAKE_ACCOUNT = "testorg-test_account",
+    SNOWFLAKE_DEFAULT_CONNECTION_NAME = "workbench",
     SNOWFLAKE_HOME = sf_home
   )
   args <- snowflake_args(driver = "driver")
@@ -167,7 +176,7 @@ test_that("Workbench-managed credentials are detected correctly", {
   expect_equal(args$authenticator, "oauth")
 })
 
-test_that("Workbench-managed credentials are ignored for other accounts", {
+test_that("Workbench-managed credentials are rejected for other accounts", {
   # Emulate the connections.toml file written by Workbench.
   sf_home <- tempfile("posit-workbench")
   dir.create(sf_home)
@@ -182,10 +191,266 @@ test_that("Workbench-managed credentials are ignored for other accounts", {
   )
   withr::local_envvar(
     SNOWFLAKE_HOME = sf_home,
+    SNOWFLAKE_DEFAULT_CONNECTION_NAME = "workbench",
     SF_PARTNER = "test_partner"
   )
   expect_snapshot(
     snowflake_args(account = "testorg-test_account", driver = "driver"),
     error = TRUE
   )
+})
+
+test_that("snowflake_connection_to_odbc_args maps fields correctly", {
+  conn <- structure(
+    list(
+      name = "test",
+      account = "testorg-test_account",
+      user = "myuser",
+      authenticator = "oauth",
+      token = structure("mytoken", class = c("snowflake_redacted", "character")),
+      warehouse = "mywh",
+      database = "mydb",
+      schema = "myschema",
+      role = "myrole"
+    ),
+    class = c("snowflake_connection", "list")
+  )
+  args <- snowflake_connection_to_odbc_args(conn)
+  expect_equal(args$uid, "myuser")
+  expect_equal(args$token, "mytoken")
+  expect_false(inherits(args$token, "snowflake_redacted"))
+  expect_equal(args$authenticator, "oauth")
+  expect_equal(args$warehouse, "mywh")
+  expect_equal(args$database, "mydb")
+  expect_equal(args$schema, "myschema")
+  expect_equal(args$role, "myrole")
+  expect_null(args$account)
+  expect_null(args$name)
+})
+
+test_that("snowflake_connection_to_odbc_args maps private key fields", {
+  conn <- structure(
+    list(
+      name = "test",
+      account = "testorg-test_account",
+      user = "myuser",
+      authenticator = "SNOWFLAKE_JWT",
+      private_key_file = "/path/to/rsa_key.p8",
+      private_key_file_pwd = structure("secret", class = c("snowflake_redacted", "character"))
+    ),
+    class = c("snowflake_connection", "list")
+  )
+  args <- snowflake_connection_to_odbc_args(conn)
+  expect_equal(args$priv_key_file, "/path/to/rsa_key.p8")
+  expect_equal(args$priv_key_file_pwd, "secret")
+  expect_false(inherits(args$priv_key_file_pwd, "snowflake_redacted"))
+  expect_equal(args$authenticator, "SNOWFLAKE_JWT")
+})
+
+test_that("snowflake_connection_to_odbc_args omits default authenticator", {
+  conn <- structure(
+    list(
+      name = "test",
+      account = "testorg-test_account",
+      user = "myuser",
+      password = structure("mypwd", class = c("snowflake_redacted", "character")),
+      authenticator = "snowflake"
+    ),
+    class = c("snowflake_connection", "list")
+  )
+  args <- snowflake_connection_to_odbc_args(conn)
+  expect_null(args$authenticator)
+  expect_equal(args$uid, "myuser")
+  expect_equal(args$pwd, "mypwd")
+  expect_false(inherits(args$pwd, "snowflake_redacted"))
+})
+
+test_that("snowflake_connection_to_odbc_args passes through token_file_path", {
+  conn <- structure(
+    list(
+      name = "test",
+      account = "testorg-test_account",
+      authenticator = "oauth",
+      token_file_path = "/snowflake/session/token"
+    ),
+    class = c("snowflake_connection", "list")
+  )
+  args <- snowflake_connection_to_odbc_args(conn)
+  expect_equal(args$token_file_path, "/snowflake/session/token")
+  expect_equal(args$authenticator, "oauth")
+})
+
+test_that("host field overrides server in snowflake_args", {
+  sf_home <- tempfile("snowflake-host-test")
+  dir.create(sf_home)
+  writeLines(
+    c(
+      '[default]',
+      'account = "testorg-test_account"',
+      'host = "custom.snowflake.example.com"',
+      'token = "token"',
+      'authenticator = "oauth"'
+    ),
+    file.path(sf_home, "connections.toml")
+  )
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "testorg-test_account",
+    SNOWFLAKE_HOME = sf_home
+  )
+  args <- snowflake_args(driver = "driver")
+  expect_equal(args$server, "custom.snowflake.example.com")
+})
+
+test_that("snowflake_server uses host when provided", {
+  expect_equal(
+    snowflake_server("testorg-test_account", host = "custom.example.com"),
+    "custom.example.com"
+  )
+  expect_equal(
+    snowflake_server("testorg-test_account", host = NULL),
+    "testorg-test_account.snowflakecomputing.com"
+  )
+  expect_equal(
+    snowflake_server("testorg-test_account", host = ""),
+    "testorg-test_account.snowflakecomputing.com"
+  )
+})
+
+test_that("explicit account works without connections.toml", {
+  sf_home <- tempfile()
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "",
+    SNOWFLAKE_HOME = sf_home
+  )
+  args <- snowflake_args(
+    account = "testorg-test_account",
+    driver = "driver",
+    uid = "user",
+    pwd = "pwd"
+  )
+  expect_equal(args$account, "testorg-test_account")
+  expect_equal(args$server, "testorg-test_account.snowflakecomputing.com")
+})
+
+test_that("connection_name selects a named connection", {
+  sf_home <- tempfile("snowflake-named")
+  dir.create(sf_home)
+  writeLines(
+    c(
+      '[default]',
+      'account = "default-account"',
+      'token = "default-token"',
+      'authenticator = "oauth"',
+      '',
+      '[production]',
+      'account = "prod-account"',
+      'token = "prod-token"',
+      'authenticator = "oauth"'
+    ),
+    file.path(sf_home, "connections.toml")
+  )
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "",
+    SNOWFLAKE_HOME = sf_home
+  )
+  args <- snowflake_args(driver = "driver", connection_name = "production")
+  expect_equal(args$account, "prod-account")
+  expect_equal(args$token, "prod-token")
+  expect_equal(args$server, "prod-account.snowflakecomputing.com")
+  expect_null(args$connection_name)
+})
+
+test_that("account is resolved from connections.toml when SNOWFLAKE_ACCOUNT is unset", {
+  sf_home <- tempfile("snowflake-no-account")
+  dir.create(sf_home)
+  writeLines(
+    c(
+      '[default]',
+      'account = "testorg-test_account"',
+      'token = "token"',
+      'authenticator = "oauth"'
+    ),
+    file.path(sf_home, "connections.toml")
+  )
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "",
+    SNOWFLAKE_HOME = sf_home
+  )
+  args <- snowflake_args(driver = "driver")
+  expect_equal(args$account, "testorg-test_account")
+  expect_equal(args$server, "testorg-test_account.snowflakecomputing.com")
+  expect_equal(args$token, "token")
+})
+
+test_that("NULL caller args don't clobber config-resolved values", {
+  sf_home <- tempfile("snowflake-null-args")
+  dir.create(sf_home)
+  writeLines(
+    c(
+      '[default]',
+      'account = "testorg-test_account"',
+      'user = "me@example.com"',
+      'authenticator = "externalbrowser"',
+      'warehouse = "mywh"',
+      'database = "mydb"',
+      'schema = "myschema"'
+    ),
+    file.path(sf_home, "connections.toml")
+  )
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "testorg-test_account",
+    SNOWFLAKE_HOME = sf_home
+  )
+  args <- snowflake_args(
+    driver = "driver",
+    uid = NULL,
+    pwd = NULL,
+    warehouse = NULL,
+    database = NULL,
+    schema = NULL
+  )
+  expect_equal(args$uid, "me@example.com")
+  expect_equal(args$authenticator, "externalbrowser")
+  expect_equal(args$warehouse, "mywh")
+  expect_equal(args$database, "mydb")
+  expect_equal(args$schema, "myschema")
+})
+
+test_that("connection_name bypasses account mismatch check", {
+  sf_home <- tempfile("snowflake-bypass")
+  dir.create(sf_home)
+  writeLines(
+    c(
+      '[myconn]',
+      'account = "other-account"',
+      'token = "tok"',
+      'authenticator = "oauth"'
+    ),
+    file.path(sf_home, "connections.toml")
+  )
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "testorg-test_account",
+    SNOWFLAKE_HOME = sf_home
+  )
+  args <- snowflake_args(driver = "driver", connection_name = "myconn")
+  expect_equal(args$account, "other-account")
+  expect_equal(args$token, "tok")
+  expect_equal(args$server, "other-account.snowflakecomputing.com")
+})
+
+test_that("workload_identity params are passed through", {
+  conn <- structure(
+    list(
+      name = "test",
+      account = "testorg-test_account",
+      authenticator = "workload_identity",
+      workload_identity_provider = "OIDC",
+      token_file_path = "/var/run/secrets/token"
+    ),
+    class = c("snowflake_connection", "list")
+  )
+  args <- snowflake_connection_to_odbc_args(conn)
+  expect_equal(args$authenticator, "workload_identity")
+  expect_equal(args$workload_identity_provider, "OIDC")
+  expect_equal(args$token_file_path, "/var/run/secrets/token")
 })


### PR DESCRIPTION
The `snowflakeauth` package targets feature parity with the `connections.toml` and `config.toml` files used in existing Snowflake packages and SDKs. This commit refactors our partial support for these files to use this package, which has a number of benefits:

* Support for non-OAuth authenticators (including "externalbrowser").
* Support for the `host` field.
* Support for named connections via a new `connection_name` argument.
* Generally improved compatibility with the Snowflake CLI and Python ecosystem.

Unit tests are included.

Note that this commit has very similar functionality to #975, but it makes use of the `snowflakeauth` package instead, part of an effort on my part to improve the consistency of our handling of Snowflake auth across the R ecosystem.