### PR TITLE
Add support for Databricks workload identity federation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
 * `databricks()` now detects service principal credentials when running on Posit
   Connect (@tnederlof, #930)
 
+* `databricks()` now supports workload identity federation.
+
 # odbc 1.6.4
 
 * Fix writing of [R] date/time values that have integer storage. (#952)

--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -11,13 +11,20 @@ NULL
 #' driver](https://www.databricks.com/spark/odbc-drivers-download).
 #'
 #' In particular, the custom `dbConnect()` method for the Databricks ODBC driver
-#' implements a subset of the [Databricks client unified authentication](https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication)
-#' model, with support for personal access tokens, OAuth machine-to-machine
-#' credentials, and OAuth user-to-machine credentials supplied via Posit
-#' Workbench or the Databricks CLI on desktop. It can also detect viewer-based
-#' and service principal credentials on Posit Connect if the \pkg{connectcreds}
-#' package is installed. All of these credentials are detected automatically if
-#' present using [standard environment variables](https://docs.databricks.com/en/dev-tools/auth.html#environment-variables-and-fields-for-client-unified-authentication).
+#' implements a variant of Databricks's [unified authentication](https://docs.databricks.com/aws/en/dev-tools/auth/unified-auth)
+#' model when no `uid` or `pwd` is supplied, checking for ambient credentials in
+#' the following order:
+#'
+#' * Viewer-based or service principal credentials supplied by Posit Connect
+#'   (requires the \pkg{connectcreds} package).
+#' * Personal access tokens.
+#' * Workload identity federation.
+#' * OAuth machine-to-machine credentials.
+#' * OAuth user-to-machine credentials suplied via Posit Workbench or the
+#'   Databricks CLI on desktop.
+#'
+#' This aims to provide broad compatibility between \pkg{odbc} and the standard
+#' environment variables used by Databricks SDKs in R and other languages.
 #'
 #' In addition, on macOS platforms, the `dbConnect()` method will check
 #' for irregularities with how the driver is configured,
@@ -260,6 +267,7 @@ databricks_auth_args <- function(host, uid = NULL, pwd = NULL) {
   # Check some standard Databricks environment variables. This is used to
   # implement a subset of the "Databricks client unified authentication" model.
   token <- Sys.getenv("DATABRICKS_TOKEN")
+  auth_type <- Sys.getenv("DATABRICKS_AUTH_TYPE")
   client_id <- Sys.getenv("DATABRICKS_CLIENT_ID")
   client_secret <- Sys.getenv("DATABRICKS_CLIENT_SECRET")
   cli_path <- Sys.getenv("DATABRICKS_CLI_PATH", "databricks")
@@ -277,6 +285,25 @@ databricks_auth_args <- function(host, uid = NULL, pwd = NULL) {
       authMech = 3,
       uid = "token",
       pwd = token
+    )
+  } else if (auth_type %in% c("env-oidc", "file-oidc")) {
+    # Next up is workload identity federation.
+    if (nchar(client_id) == 0) {
+      cli::cli_abort(
+        c(
+          "Workload identity federation requires a service principal.",
+          "i" = "Set the {.envvar DATABRICKS_CLIENT_ID} environment variable to
+                 the service principal's UUID."
+        ),
+        call = quote(DBI::dbConnect())
+      )
+    }
+    id_token <- databricks_read_id_token(auth_type)
+    access_token <- databricks_token_exchange(host, id_token, client_id)
+    list(
+      authMech = 11,
+      auth_flow = 0,
+      auth_accesstoken = access_token
     )
   } else if (nchar(client_id) != 0) {
     # Next up are explicit OAuth2 M2M credentials.
@@ -315,6 +342,121 @@ databricks_auth_args <- function(host, uid = NULL, pwd = NULL) {
       )
     }
   }
+}
+
+databricks_read_id_token <- function(auth_type) {
+  if (auth_type == "env-oidc") {
+    token_env_name <- Sys.getenv("DATABRICKS_OIDC_TOKEN_ENV")
+    if (nchar(token_env_name) == 0) {
+      token_env_name <- "DATABRICKS_OIDC_TOKEN"
+    }
+    token <- Sys.getenv(token_env_name)
+    if (nchar(token) == 0) {
+      cli::cli_abort(
+        c(
+          "Workload identity federation is enabled
+           ({.code DATABRICKS_AUTH_TYPE=env-oidc}) but no OIDC token was found.",
+          "i" = "Set the {.envvar {token_env_name}} environment variable to the
+                 IdP JWT."
+        ),
+        call = quote(DBI::dbConnect())
+      )
+    }
+    token
+  } else {
+    path <- Sys.getenv("DATABRICKS_OIDC_TOKEN_FILEPATH")
+    if (nchar(path) == 0) {
+      cli::cli_abort(
+        c(
+          "Workload identity federation is enabled
+           ({.code DATABRICKS_AUTH_TYPE=file-oidc}) but
+           {.envvar DATABRICKS_OIDC_TOKEN_FILEPATH} is not set.",
+          "i" = "Set {.envvar DATABRICKS_OIDC_TOKEN_FILEPATH} to the path of the
+                 file containing the IdP JWT."
+        ),
+        call = quote(DBI::dbConnect())
+      )
+    }
+    if (!file.exists(path)) {
+      cli::cli_abort(
+        c(
+          "OIDC token file {.file {path}} does not exist.",
+          "i" = "Verify {.envvar DATABRICKS_OIDC_TOKEN_FILEPATH} points to a
+                 readable file."
+        ),
+        call = quote(DBI::dbConnect())
+      )
+    }
+    token <- trimws(paste(readLines(path, warn = FALSE), collapse = ""))
+    if (nchar(token) == 0) {
+      cli::cli_abort(
+        "OIDC token file {.file {path}} is empty.",
+        call = quote(DBI::dbConnect())
+      )
+    }
+    token
+  }
+}
+
+databricks_token_exchange <- function(host, id_token, client_id) {
+  check_installed("httr2", "for Databricks workload identity federation")
+
+  url <- paste0("https://", host, "/oidc/v1/token")
+  body <- list(
+    grant_type = "urn:ietf:params:oauth:grant-type:token-exchange",
+    subject_token_type = "urn:ietf:params:oauth:token-type:jwt",
+    subject_token = id_token,
+    scope = "all-apis",
+    client_id = client_id
+  )
+
+  req <- httr2::request(url)
+  req <- httr2::req_body_form(req, !!!body)
+  req <- httr2::req_error(req, is_error = function(resp) FALSE)
+
+  resp <- try_fetch(
+    httr2::req_perform(req),
+    error = function(cnd) {
+      cli::cli_abort(
+        c(
+          "Failed to reach the Databricks OIDC token endpoint at {.url {url}}.",
+          "i" = "Check network connectivity and that {.arg workspace} is correct."
+        ),
+        parent = cnd,
+        call = quote(DBI::dbConnect())
+      )
+    }
+  )
+
+  if (httr2::resp_is_error(resp)) {
+    status <- httr2::resp_status(resp)
+    resp_body <- tryCatch(
+      httr2::resp_body_string(resp),
+      error = function(e) "(unreadable)"
+    )
+    cli::cli_abort(
+      c(
+        "Databricks OIDC token exchange failed with HTTP {status}.",
+        "i" = "Response: {resp_body}"
+      ),
+      call = quote(DBI::dbConnect())
+    )
+  }
+
+  parsed <- httr2::resp_body_json(resp)
+  access_token <- parsed$access_token
+  if (is.null(access_token) || !nzchar(access_token)) {
+    cli::cli_abort(
+      c(
+        "Databricks OIDC token exchange response did not contain an access
+         token.",
+        "i" = "Verify the federation policy is configured correctly in
+               Databricks."
+      ),
+      call = quote(DBI::dbConnect())
+    )
+  }
+  access_token
 }
 
 # Try to determine whether we can redirect the user's browser to a server on

--- a/man/databricks.Rd
+++ b/man/databricks.Rd
@@ -53,13 +53,21 @@ cluster or SQL warehouse.
 Connect to Databricks clusters and SQL warehouses via the \href{https://www.databricks.com/spark/odbc-drivers-download}{Databricks ODBC driver}.
 
 In particular, the custom \code{dbConnect()} method for the Databricks ODBC driver
-implements a subset of the \href{https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication}{Databricks client unified authentication}
-model, with support for personal access tokens, OAuth machine-to-machine
-credentials, and OAuth user-to-machine credentials supplied via Posit
-Workbench or the Databricks CLI on desktop. It can also detect viewer-based
-and service principal credentials on Posit Connect if the \pkg{connectcreds}
-package is installed. All of these credentials are detected automatically if
-present using \href{https://docs.databricks.com/en/dev-tools/auth.html#environment-variables-and-fields-for-client-unified-authentication}{standard environment variables}.
+implements a variant of Databricks's \href{https://docs.databricks.com/aws/en/dev-tools/auth/unified-auth}{unified authentication}
+model when no \code{uid} or \code{pwd} is supplied, checking for ambient credentials in
+the following order:
+\itemize{
+\item Viewer-based or service principal credentials supplied by Posit Connect
+(requires the \pkg{connectcreds} package).
+\item Personal access tokens.
+\item Workload identity federation.
+\item OAuth machine-to-machine credentials.
+\item OAuth user-to-machine credentials suplied via Posit Workbench or the
+Databricks CLI on desktop.
+}
+
+This aims to provide broad compatibility between \pkg{odbc} and the standard
+environment variables used by Databricks SDKs in R and other languages.
 
 In addition, on macOS platforms, the \code{dbConnect()} method will check
 for irregularities with how the driver is configured,

--- a/tests/testthat/_snaps/driver-databricks.md
+++ b/tests/testthat/_snaps/driver-databricks.md
@@ -68,3 +68,65 @@
       i Supply `uid` and `pwd` to authenticate manually.
       i Or consider enabling Posit Connect's Databricks integration.  For viewer-based credentials, see <https://docs.posit.co/connect/user/oauth-integrations/#viewer-oauth-integrations> for details.  For service principal credentials, see <https://docs.posit.co/connect/user/oauth-integrations/#service-account-oauth-integrations> for details.
 
+# workload identity errors when DATABRICKS_CLIENT_ID is not set
+
+    Code
+      databricks_auth_args("host")
+    Condition
+      Error in `DBI::dbConnect()`:
+      ! Workload identity federation requires a service principal.
+      i Set the `DATABRICKS_CLIENT_ID` environment variable to the service principal's UUID.
+
+# workload identity env-oidc errors when JWT env var is empty
+
+    Code
+      databricks_auth_args("host")
+    Condition
+      Error in `DBI::dbConnect()`:
+      ! Workload identity federation is enabled (`DATABRICKS_AUTH_TYPE=env-oidc`) but no OIDC token was found.
+      i Set the `DATABRICKS_OIDC_TOKEN` environment variable to the IdP JWT.
+
+# workload identity file-oidc errors when filepath is not set
+
+    Code
+      databricks_auth_args("host")
+    Condition
+      Error in `DBI::dbConnect()`:
+      ! Workload identity federation is enabled (`DATABRICKS_AUTH_TYPE=file-oidc`) but `DATABRICKS_OIDC_TOKEN_FILEPATH` is not set.
+      i Set `DATABRICKS_OIDC_TOKEN_FILEPATH` to the path of the file containing the IdP JWT.
+
+# workload identity file-oidc errors when file does not exist
+
+    Code
+      databricks_auth_args("host")
+    Condition
+      Error in `DBI::dbConnect()`:
+      ! OIDC token file '/nonexistent/path/to/jwt' does not exist.
+      i Verify `DATABRICKS_OIDC_TOKEN_FILEPATH` points to a readable file.
+
+# workload identity file-oidc errors when file is empty
+
+    Code
+      databricks_auth_args("host")
+    Condition
+      Error in `DBI::dbConnect()`:
+      ! OIDC token file '<tempfile>' is empty.
+
+# databricks_token_exchange errors on HTTP failure
+
+    Code
+      databricks_token_exchange("host.example.com", "bad-jwt", "sp-id")
+    Condition
+      Error in `DBI::dbConnect()`:
+      ! Databricks OIDC token exchange failed with HTTP 400.
+      i Response: {"error":"invalid_grant"}
+
+# databricks_token_exchange errors when access_token is missing
+
+    Code
+      databricks_token_exchange("host.example.com", "jwt", "sp-id")
+    Condition
+      Error in `DBI::dbConnect()`:
+      ! Databricks OIDC token exchange response did not contain an access token.
+      i Verify the federation policy is configured correctly in Databricks.
+

--- a/tests/testthat/test-driver-databricks.R
+++ b/tests/testthat/test-driver-databricks.R
@@ -1,5 +1,5 @@
 test_that("databricks arguments use camelcase", {
-  withr::local_envvar(DATABRICKS_TOKEN = "")
+  withr::local_envvar(DATABRICKS_TOKEN = "", DATABRICKS_AUTH_TYPE = "")
 
   args <- databricks_args(
     "foo",
@@ -55,6 +55,7 @@ test_that("user agent respects envvar", {
 test_that("errors if auth fails", {
   withr::local_envvar(
     DATABRICKS_TOKEN = "",
+    DATABRICKS_AUTH_TYPE = "",
     DATABRICKS_CONFIG_FILE = NULL
   )
 
@@ -175,4 +176,218 @@ test_that("tokens can be requested from a Connect server", {
     databricks_auth_args("example.cloud.databricks.com"),
     list(authMech = 11, auth_flow = 0, auth_accesstoken = "token")
   )
+})
+
+test_that("supports workload identity env-oidc with default token env var", {
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "my-sp",
+    DATABRICKS_AUTH_TYPE = "env-oidc",
+    DATABRICKS_OIDC_TOKEN = "my-jwt",
+    DATABRICKS_OIDC_TOKEN_ENV = ""
+  )
+  local_mocked_bindings(
+    databricks_token_exchange = function(host, id_token, client_id) {
+      expect_equal(id_token, "my-jwt")
+      expect_equal(client_id, "my-sp")
+      "exchanged-access-token"
+    }
+  )
+  auth <- databricks_auth_args("my.cloud.databricks.com")
+  expect_equal(auth$authMech, 11)
+  expect_equal(auth$auth_flow, 0)
+  expect_equal(auth$auth_accesstoken, "exchanged-access-token")
+})
+
+test_that("supports workload identity env-oidc with custom token env var name", {
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "sp",
+    DATABRICKS_AUTH_TYPE = "env-oidc",
+    DATABRICKS_OIDC_TOKEN_ENV = "MY_CUSTOM_JWT_VAR",
+    MY_CUSTOM_JWT_VAR = "custom-jwt"
+  )
+  local_mocked_bindings(
+    databricks_token_exchange = function(host, id_token, client_id) {
+      expect_equal(id_token, "custom-jwt")
+      "token"
+    }
+  )
+  auth <- databricks_auth_args("host")
+  expect_equal(auth$auth_accesstoken, "token")
+})
+
+test_that("workload identity env-oidc falls back when OIDC_TOKEN_ENV is empty", {
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "sp",
+    DATABRICKS_AUTH_TYPE = "env-oidc",
+    DATABRICKS_OIDC_TOKEN_ENV = "",
+    DATABRICKS_OIDC_TOKEN = "fallback-jwt"
+  )
+  local_mocked_bindings(
+    databricks_token_exchange = function(host, id_token, client_id) {
+      expect_equal(id_token, "fallback-jwt")
+      "token"
+    }
+  )
+  auth <- databricks_auth_args("host")
+  expect_equal(auth$auth_accesstoken, "token")
+})
+
+test_that("supports workload identity file-oidc", {
+  token_file <- withr::local_tempfile()
+  writeLines("file-jwt", token_file)
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "sp",
+    DATABRICKS_AUTH_TYPE = "file-oidc",
+    DATABRICKS_OIDC_TOKEN = "",
+    DATABRICKS_OIDC_TOKEN_ENV = "",
+    DATABRICKS_OIDC_TOKEN_FILEPATH = token_file
+  )
+  local_mocked_bindings(
+    databricks_token_exchange = function(host, id_token, client_id) {
+      expect_equal(id_token, "file-jwt")
+      "exchanged-token"
+    }
+  )
+  auth <- databricks_auth_args("host")
+  expect_equal(auth$auth_accesstoken, "exchanged-token")
+})
+
+test_that("workload identity errors when DATABRICKS_CLIENT_ID is not set", {
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "",
+    DATABRICKS_AUTH_TYPE = "env-oidc",
+    DATABRICKS_OIDC_TOKEN = "jwt"
+  )
+  expect_snapshot(databricks_auth_args("host"), error = TRUE)
+})
+
+test_that("workload identity env-oidc errors when JWT env var is empty", {
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "sp",
+    DATABRICKS_AUTH_TYPE = "env-oidc",
+    DATABRICKS_OIDC_TOKEN = "",
+    DATABRICKS_OIDC_TOKEN_ENV = ""
+  )
+  expect_snapshot(databricks_auth_args("host"), error = TRUE)
+})
+
+test_that("workload identity file-oidc errors when filepath is not set", {
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "sp",
+    DATABRICKS_AUTH_TYPE = "file-oidc",
+    DATABRICKS_OIDC_TOKEN = "",
+    DATABRICKS_OIDC_TOKEN_ENV = "",
+    DATABRICKS_OIDC_TOKEN_FILEPATH = ""
+  )
+  expect_snapshot(databricks_auth_args("host"), error = TRUE)
+})
+
+test_that("workload identity file-oidc errors when file does not exist", {
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "sp",
+    DATABRICKS_AUTH_TYPE = "file-oidc",
+    DATABRICKS_OIDC_TOKEN = "",
+    DATABRICKS_OIDC_TOKEN_ENV = "",
+    DATABRICKS_OIDC_TOKEN_FILEPATH = "/nonexistent/path/to/jwt"
+  )
+  expect_snapshot(databricks_auth_args("host"), error = TRUE)
+})
+
+test_that("workload identity file-oidc errors when file is empty", {
+  token_file <- withr::local_tempfile()
+  writeLines("", token_file)
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "sp",
+    DATABRICKS_AUTH_TYPE = "file-oidc",
+    DATABRICKS_OIDC_TOKEN = "",
+    DATABRICKS_OIDC_TOKEN_ENV = "",
+    DATABRICKS_OIDC_TOKEN_FILEPATH = token_file
+  )
+  expect_snapshot(
+    databricks_auth_args("host"),
+    error = TRUE,
+    transform = function(x) gsub(token_file, "<tempfile>", x, fixed = TRUE)
+  )
+})
+
+test_that("DATABRICKS_TOKEN takes precedence over workload identity", {
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "my-pat",
+    DATABRICKS_CLIENT_ID = "sp",
+    DATABRICKS_AUTH_TYPE = "env-oidc",
+    DATABRICKS_OIDC_TOKEN = "my-jwt",
+    DATABRICKS_OIDC_TOKEN_ENV = ""
+  )
+  auth <- databricks_auth_args("host")
+  expect_equal(auth$pwd, "my-pat")
+  expect_equal(auth$authMech, 3)
+})
+
+test_that("databricks_token_exchange extracts access_token from response", {
+  skip_if_not_installed("httr2")
+  httr2::local_mocked_responses(function(req) {
+    httr2::response(
+      status_code = 200L,
+      headers = list(`content-type` = "application/json"),
+      body = charToRaw(
+        '{"access_token":"tok123","token_type":"Bearer","expires_in":3600}'
+      )
+    )
+  })
+  result <- databricks_token_exchange("host.example.com", "jwt", "sp-id")
+  expect_equal(result, "tok123")
+})
+
+test_that("databricks_token_exchange errors on HTTP failure", {
+  skip_if_not_installed("httr2")
+  httr2::local_mocked_responses(function(req) {
+    httr2::response(
+      status_code = 400L,
+      headers = list(`content-type` = "application/json"),
+      body = charToRaw('{"error":"invalid_grant"}')
+    )
+  })
+  expect_snapshot(
+    databricks_token_exchange("host.example.com", "bad-jwt", "sp-id"),
+    error = TRUE
+  )
+})
+
+test_that("databricks_token_exchange errors when access_token is missing", {
+  skip_if_not_installed("httr2")
+  httr2::local_mocked_responses(function(req) {
+    httr2::response(
+      status_code = 200L,
+      headers = list(`content-type` = "application/json"),
+      body = charToRaw('{"token_type":"Bearer"}')
+    )
+  })
+  expect_snapshot(
+    databricks_token_exchange("host.example.com", "jwt", "sp-id"),
+    error = TRUE
+  )
+})
+
+test_that("DATABRICKS_CLIENT_ID still triggers M2M when AUTH_TYPE is not workload identity", {
+  withr::local_envvar(
+    DATABRICKS_TOKEN = "",
+    DATABRICKS_CLIENT_ID = "abc",
+    DATABRICKS_CLIENT_SECRET = "def",
+    DATABRICKS_AUTH_TYPE = "",
+    DATABRICKS_OIDC_TOKEN = "",
+    DATABRICKS_OIDC_TOKEN_ENV = ""
+  )
+  auth <- databricks_auth_args("host")
+  expect_equal(auth$auth_client_id, "abc")
+  expect_equal(auth$auth_client_secret, "def")
+  expect_equal(auth$auth_flow, 1)
 })


### PR DESCRIPTION
Databricks recently added support for [workload identity federation][0], and Posit Connect now supports it as well, but only for Python content up until now. This commit wires up workload identity inside `odbc::databricks()`.

Unit tests are included, as are updates to the documentation.

[0]: https://docs.databricks.com/aws/en/dev-tools/auth/oauth-federation-exchange