### PR TITLE
resolve NOTE on `odbc_result.o`

### DIFF
--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -1161,7 +1161,7 @@ std::pair<bool, cctz::time_zone> odbc_result::get_tz_bind_info(
       std::string tzonestr = Rcpp::as<std::string>(tzone);
       cctz::time_zone tz;
       if (!cctz::load_time_zone(tzonestr.data(), &tz)) {
-        std::cerr << "Failed to load time zone" << std::endl;
+        Rcpp::Rcerr << "Failed to load time zone" << std::endl;
         return {false, c_->timezone()};
       }
       return {true, tz};


### PR DESCRIPTION
On `devtools::check_win_devel()`, I see:

```
* checking compiled code ... NOTE
File 'odbc/libs/x64/odbc.dll':
  Found '_ZSt4cerr', possibly from 'std::cerr' (C++)
    Object: 'odbc_result.o'

Compiled code should not call entry points which might terminate R nor
write to stdout/stderr instead of to the console, nor use Fortran I/O
nor system RNGs nor [v]sprintf.

See 'Writing portable packages' in the 'Writing R Extensions' manual.
```

Note that this is a stacked PR into #1004.