### PR TITLE
tests: sql-server: skip recycling test on older PRO drivers

### DIFF
--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -526,6 +526,15 @@ test_that("Recycling in dbBind works (#491)", {
   rownames(dat_expect) <- NULL
 
   con <- test_con("SQLSERVER")
+  # Relies on the PRO engineering build (1.5.49.0049) fix for binding multiple
+  # parameters of length > 1 (parameter recycling, #491).
+  drv <- DBI::dbGetInfo(con)$driver.version
+  skip_if(
+    identical(Sys.getenv("ODBC_DRIVERS_VINTAGE"), "PRO") &&
+      length(drv) == 1 && nzchar(drv) &&
+      numeric_version(drv) < numeric_version("1.5.49.0049"),
+    sprintf("PRO driver %s is older than engineering build 1.5.49.0049", drv)
+  )
   tbl_name <- local_table(con, "recyclingtemptable", dat_in,
                           field.types = c(id = "int", timestamp = "DATETIMEOFFSET"))
 


### PR DESCRIPTION
Verified to work against engineering build 1.5.49.0049

Closes #991 