### PR TITLE
fix: avoid scientific notation in numeric connection attributes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # odbc (development version)
 
+* Numeric connection string arguments no longer fall back to scientific
+  notation in `build_connection_string()`, which avoids malformed driver
+  attributes such as `DefaultStringColumnLength` (#934).
+
 # odbc 1.7.0
 
 ## Databricks

--- a/R/utils.R
+++ b/R/utils.R
@@ -584,7 +584,25 @@ find_default_driver <- function(paths, fallbacks, label, call = caller_env()) {
 #' @return string A finalized connection string
 #' @noRd
 build_connection_string <- function(args = list(), string = NULL) {
+  format_connection_value <- function(x) {
+    if (length(x) != 1) {
+      return(paste(deparse(x), collapse = " "))
+    }
 
+    if (is.numeric(x) && length(x) == 1 && !is.na(x)) {
+      return(format(
+        x,
+        scientific = FALSE,
+        trim = TRUE,
+        digits = 15,
+        decimal.mark = "."
+      ))
+    }
+
+    as.character(x)
+  }
+
+  args <- vapply(args, format_connection_value, character(1))
   args_string <- paste(names(args), args, sep = "=", collapse = ";")
 
   if (!is.null(string) && !grepl(";$", string) && length(args) > 0) {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -399,6 +399,17 @@ test_that("combines with existing .connection string", {
   expect_equal(build_connection_string(list(foo = "1"), "x=1;"), "x=1;foo=1")
 })
 
+test_that("formats numeric connection string values without scientific notation", {
+  expect_equal(
+    build_connection_string(list(DefaultStringColumnLength = 100000)),
+    "DefaultStringColumnLength=100000"
+  )
+  expect_equal(
+    build_connection_string(list(foo = 0.00001, bar = 1.23)),
+    "foo=0.00001;bar=1.23"
+  )
+})
+
 test_that("Handles connection string as expected", {
   conn_string <- build_connection_string(list(dsn = "abc",
     k1 = quote_value("Quoted Value"),


### PR DESCRIPTION
Summary

Avoid scientific notation when `build_connection_string()` formats numeric
connection attributes, so large values such as `DefaultStringColumnLength`
stay literal in the final ODBC connection string.

Thanks to maintainers

Thanks for maintaining `odbc` and for the concrete report in `#934`.

Issue or motivation

`build_connection_string()` currently relies on the default character coercion
 for numeric values. Large or small numerics can therefore become strings like
`1e+05` or `1e-05`, which some drivers do not accept for connection
attributes.

Root cause

`build_connection_string()` pastes argument values directly, so numeric
arguments inherit R's default scientific notation instead of a plain literal
representation suitable for connection-string attributes.

Change

- Format scalar numeric connection arguments with fixed decimal output and no
  scientific notation.
- Preserve the previous fallback stringification for non-scalar values.
- Add regression coverage for large and small numeric connection attributes.
- Note the fix in `NEWS.md`.

Tests

- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); testthat::test_file("tests/testthat/test-utils.R")'`
- `R CMD build .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual odbc_1.7.0.9000.tar.gz`

Scope

This stays within connection-string assembly in `build_connection_string()`.
It does not change driver-specific argument helpers, ODBC quoting rules, or
other numeric formatting paths outside connection-string construction.
