### PR TITLE
Re-enable Windows R-4.1 CI job and pin paws.common (>= 0.7.1)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,6 +27,8 @@ jobs:
           - {os: macos-latest,   r: 'release'}
 
           - {os: windows-latest, r: 'release'}
+          # use 4.1 to check with rtools40's older compiler
+          - {os: windows-latest, r: '4.1'}
 
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'release'}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     httr2,
     knitr,
     magrittr,
-    paws.common,
+    paws.common (>= 0.7.1),
     rmarkdown,
     RSQLite,
     snowflakeauth,


### PR DESCRIPTION
The `os: windows-latest, r: '4.1'` R-CMD-check job was removed in #973 because paws.common wouldn't build from source under rtools40/C++11 on win/4.1.

Reported the issue to the `paws.common` maintainers and looks like they addressed the issue --- it now builds from source under C++11, so that constraint is gone. This restores the job and pins the dependency accordingly.