### PR TITLE
nanodbc: handle SQL_NO_TOTAL when retrieving binary data in chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # odbc (development version)
 
+* Fixed silent truncation of `BINARY`/`VARBINARY` data larger than 1024 bytes
+  when the driver does not report the remaining data length (`SQL_NO_TOTAL`)
+  during chunked retrieval, as seen with the Databricks/Simba Spark
+  driver (#1024).
+
 * Numeric connection string arguments no longer fall back to scientific
   notation in `build_connection_string()`, which avoids malformed driver
   attributes such as `DefaultStringColumnLength` (#934).

--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -4273,7 +4273,9 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
                     buffer,          // TargetValuePtr
                     buffer_size,     // BufferLength
                     &ValueLenOrInd); // StrLen_or_IndPtr
-                if (ValueLenOrInd > 0)
+                if (ValueLenOrInd == SQL_NO_TOTAL)
+                    out.insert(std::end(out), buffer, buffer + buffer_size);
+                else if (ValueLenOrInd > 0)
                 {
                     auto const buffer_size_filled =
                         std::min<std::size_t>(ValueLenOrInd, buffer_size);


### PR DESCRIPTION
Fixes #1024.

## Problem

When retrieving unbound `SQL_C_BINARY` columns, nanodbc reads the value in 1024-byte chunks via repeated `SQLGetData` calls. The loop in `get_ref_impl<std::vector<std::uint8_t>>` only appended a chunk when the length indicator was positive:

```cpp
if (ValueLenOrInd > 0) { ... out.insert(...) ... }
```

Per the ODBC spec, a driver may instead set the indicator to `SQL_NO_TOTAL` (−4) on intermediate `SQL_SUCCESS_WITH_INFO` calls when it does not know the remaining data length — which is what the Databricks/Simba Spark driver does. Since −4 fails the `> 0` test, every full 1024-byte chunk was silently discarded, and only the final chunk (returned with `SQL_SUCCESS` and a real length) was kept. That yields exactly the behavior reported in #1024: `n mod 1024` bytes returned, with exact multiples of 1024 surviving intact.

(One note on the issue's analysis: the returned bytes are the *last* chunk, not a prefix — the reporter's prefix check used a period-256 payload with a length that is a multiple of 1024, where the two are byte-identical.)

## Fix

Handle `SQL_NO_TOTAL` by appending the full buffer, exactly mirroring the existing `SQL_C_CHAR` and `SQL_C_WCHAR` blob paths a few lines above (which already have this branch). On `SQL_SUCCESS_WITH_INFO`/01004 with `SQL_C_BINARY` the driver fills the entire buffer, so appending `buffer_size` is correct.

## Testing

There is no regression test because reproducing this requires a driver that reports `SQL_NO_TOTAL` for binary chunks (the Simba Spark driver does; the drivers in CI report actual remaining lengths, which take the already-correct `ValueLenOrInd > 0` path). Verification against a Databricks warehouse per the repro in #1024 would be welcome.

Upstream nanodbc `main` has the identical gap in the binary path; I'd suggest upstreaming this patch as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)