### PR TITLE
fix: disambiguate odbcConnectionColumns S4 dispatch for Oracle/Snowflake

### DIFF
--- a/R/driver-oracle.R
+++ b/R/driver-oracle.R
@@ -143,6 +143,18 @@ setMethod("odbcConnectionColumns", c("Oracle", "character"),
   }
 )
 
+#' @description
+#' ## `odbcConnectionColumns()`
+#'
+#' Defined explicitly (rather than inherited) to avoid an ambiguous S4 dispatch
+#' @rdname Oracle
+#' @usage NULL
+setMethod("odbcConnectionColumns", c("Oracle", "SQL"),
+  function(conn, name, ..., exact = FALSE) {
+    odbcConnectionColumns(conn, dbUnquoteIdentifier(conn, name)[[1]], ..., exact = exact)
+  }
+)
+
 #' @export
 #' @rdname odbcDataType
 #' @usage NULL

--- a/R/driver-snowflake.R
+++ b/R/driver-snowflake.R
@@ -55,6 +55,15 @@ setMethod("odbcConnectionColumns", c("Snowflake", "character"),
   }
 )
 
+# Defined explicitly (rather than inherited) to avoid an ambiguous S4 dispatch
+#' @rdname driver-Snowflake
+#' @usage NULL
+setMethod("odbcConnectionColumns", c("Snowflake", "SQL"),
+  function(conn, name, ..., exact = FALSE) {
+    odbcConnectionColumns(conn, dbUnquoteIdentifier(conn, name)[[1]], ..., exact = exact)
+  }
+)
+
 #' @rdname driver-Snowflake
 setMethod("dbExistsTableForWrite", c("Snowflake", "character"),
   function(conn, name, ...,

--- a/tests/testthat/test-odbc-connection.R
+++ b/tests/testthat/test-odbc-connection.R
@@ -65,3 +65,29 @@ test_that("validateObjectName() errors informatively", {
     odbcListColumns(con)
   )
 })
+
+# odbcConnectionColumns S4 dispatch ---------------------------------------
+
+test_that("odbcConnectionColumns has no ambiguous (Driver, SQL) dispatch", {
+  # `SQL` extends `character`, so a driver that defines only a
+  # `c(Driver, "character")` method leaves `(Driver, SQL)` ambiguous against the
+  # base `c("OdbcConnection", "SQL")` method, producing an S4 NOTE. Drivers that
+  # override the character method must also define the SQL method.
+  for (driver in c("Oracle", "Snowflake", "Microsoft SQL Server")) {
+    expect_true(
+      existsMethod("odbcConnectionColumns", c(driver, "SQL")),
+      info = driver
+    )
+    # The exact method must win, with no ambiguity message emitted.
+    msgs <- character()
+    m <- withCallingHandlers(
+      selectMethod("odbcConnectionColumns", signature(driver, "SQL")),
+      message = function(c) {
+        msgs <<- c(msgs, conditionMessage(c))
+        invokeRestart("muffleMessage")
+      }
+    )
+    expect_identical(as.character(m@target), c(driver, "SQL"), info = driver)
+    expect_false(any(grepl("would also be valid", msgs)), info = driver)
+  }
+})


### PR DESCRIPTION
This is long overdue --- fixing a note when executing some `oracle` api calls.

```
Note: method with signature 'Oracle#character' chosen for function 'odbcConnectionColumns',
 target signature 'Oracle#SQL'.
 "OdbcConnection#SQL" would also be valid
```

See for example CI db/linux test runs.