### PR TITLE
nanodbc: include <locale> for wstring_convert (clang 23 / libc++ 23)

### DIFF
--- a/src/nanodbc/nanodbc.cpp
+++ b/src/nanodbc/nanodbc.cpp
@@ -45,6 +45,9 @@
 #define NANODBC_USE_NATIVE_CONVERT
 #else
 #include <codecvt>
+// wstring_convert is declared in <locale>, which libc++ 23 no longer
+// includes transitively via <codecvt>
+#include <locale>
 #endif
 #endif
 

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -28,7 +28,7 @@
       ! ODBC failed with error 00000 from [unixODBC][Driver Manager].
       x Data source name not found and no default driver specified
       i See `?odbc::odbcListDataSources()` to learn more.
-      i From 'nanodbc/nanodbc.cpp:1184'.
+      i From 'nanodbc/nanodbc.cpp:1187'.
 
 ---
 
@@ -39,7 +39,7 @@
       ! ODBC failed with error 00000 from [SQLite].
       x no such table: boopbopbopbeep (1)
       * <SQL> 'SELECT * FROM boopbopbopbeep'
-      i From 'nanodbc/nanodbc.cpp:1802'.
+      i From 'nanodbc/nanodbc.cpp:1805'.
 
 # rethrow_database_error() errors well when parse_database_error() fails
 


### PR DESCRIPTION
Fixes #1031 

This is a stop-gap solution. The proper solution is to upgrade our vendored nanodbc, see https://github.com/r-dbi/odbc/issues/1027. However that is a much larger, potentially breaking change, that requires more careful testing.