### PR TITLE
Require R 4.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ URL: https://odbc.r-dbi.org, https://github.com/r-dbi/odbc,
     https://solutions.posit.co/connections/db/
 BugReports: https://github.com/r-dbi/odbc/issues
 Depends: 
-    R (>= 4.0.0)
+    R (>= 4.2.0)
 Imports:
     bit64,
     blob (>= 1.2.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # odbc (development version)
 
+* odbc now requires R 4.2.0.
+
 * Update vendored cctz to current upstream, including local build compatibility
   fixes retained for R package and Windows builds.
 

--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -49,7 +49,7 @@ odbcListObjectTypes.default <- function(connection) {
   viewlike <- grep("view", table_types, value = TRUE)
   viewlike_types <- sapply(
     viewlike,
-    function(i) list(contains = "data", icon = "connections/objects/view.png"),
+    \(i) list(contains = "data", icon = "connections/objects/view.png"),
     simplify = FALSE
   )
   obj_types <- c(obj_types, viewlike_types)
@@ -103,14 +103,13 @@ odbcListObjects.OdbcConnection <- function(connection,
   if (is.null(catalog)) {
     catalogs <- tryCatch(
       string_values(odbcConnectionCatalogs(connection)),
-      error = function(err) character()
+      error = \(err) character()
     )
     if (length(catalogs) > 0) {
       return(
         data.frame(
           name = catalogs,
-          type = rep("catalog", times = length(catalogs)),
-          stringsAsFactors = FALSE
+          type = rep("catalog", times = length(catalogs))
         )
       )
     }
@@ -124,8 +123,7 @@ odbcListObjects.OdbcConnection <- function(connection,
       return(
         data.frame(
           name = schemas,
-          type = rep("schema", times = length(schemas)),
-          stringsAsFactors = FALSE
+          type = rep("schema", times = length(schemas))
         )
       )
     }
@@ -133,14 +131,13 @@ odbcListObjects.OdbcConnection <- function(connection,
 
   objs <- tryCatch(
     odbcConnectionTables(connection, name, catalog, schema, table_type = type),
-    error = function(e) NULL
+    error = \(e) NULL
   )
   # just return a list of the objects and their types, possibly filtered by the
   # options above
   data.frame(
     name = objs[["table_name"]],
-    type = tolower(objs[["table_type"]]),
-    stringsAsFactors = FALSE
+    type = tolower(objs[["table_type"]])
   )
 }
 
@@ -235,8 +232,7 @@ odbcListColumns.OdbcConnection <- function(connection,
   # extract and name fields for observer
   data.frame(
     name = cols[["name"]],
-    type = cols[["field.type"]],
-    stringsAsFactors = FALSE
+    type = cols[["field.type"]]
   )
 }
 
@@ -379,7 +375,7 @@ odbcConnectionActions <- function(connection) {
           icon = system.file("icons/edit-sql.png", package = "odbc"),
           callback = function() {
             varname <- Filter(
-              function(e) identical(get(e, envir = .GlobalEnv), connection),
+              \(e) identical(get(e, envir = .GlobalEnv), connection),
               ls(envir = .GlobalEnv)
             )
 

--- a/R/dbi-table.R
+++ b/R/dbi-table.R
@@ -189,11 +189,11 @@ setMethod("sqlData", "OdbcConnection",
     value <- sqlRownamesToColumn(value, row.names)
 
     # Convert POSIXlt to POSIXct
-    is_POSIXlt <- vapply(value, function(x) is.object(x) && (is(x, "POSIXlt")), logical(1))
+    is_POSIXlt <- vapply(value, \(x) is.object(x) && (is(x, "POSIXlt")), logical(1))
     value[is_POSIXlt] <- lapply(value[is_POSIXlt], as.POSIXct)
 
     # C code takes care of atomic vectors, dates, date times, and blobs just need to coerce other objects
-    is_object <- vapply(value, function(x) is.object(x) && !(is(x, "POSIXct") || is(x, "Date") || is_blob(x) || is(x, "difftime")), logical(1))
+    is_object <- vapply(value, \(x) is.object(x) && !(is(x, "POSIXct") || is(x, "Date") || is_blob(x) || is(x, "difftime")), logical(1))
     value[is_object] <- lapply(value[is_object], as.character)
 
     if (nzchar(con@encoding)) {

--- a/R/driver-databricks.R
+++ b/R/driver-databricks.R
@@ -423,7 +423,7 @@ databricks_token_exchange <- function(host, id_token, client_id) {
 
   req <- httr2::request(url)
   req <- httr2::req_body_form(req, !!!body)
-  req <- httr2::req_error(req, is_error = function(resp) FALSE)
+  req <- httr2::req_error(req, is_error = \(resp) FALSE)
 
   resp <- try_fetch(
     httr2::req_perform(req),
@@ -443,7 +443,7 @@ databricks_token_exchange <- function(host, id_token, client_id) {
     status <- httr2::resp_status(resp)
     resp_body <- tryCatch(
       httr2::resp_body_string(resp),
-      error = function(e) "(unreadable)"
+      error = \(e) "(unreadable)"
     )
     cli::cli_abort(
       c(

--- a/R/driver-teradata.R
+++ b/R/driver-teradata.R
@@ -62,8 +62,7 @@ setMethod("odbcConnectionTables", c("Teradata", "character"),
         table_catalog = navec,
         table_schema = navec,
         table_name = tempTableNames,
-        table_remarks = navec,
-        stringsAsFactors = FALSE
+        table_remarks = navec
       )
     )
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,7 +11,7 @@ has_names <- function(x) {
 
 string_values <- function(x) {
   # TODO: Throw a condition object that can be caught for debugging purposes
-  x <- tryCatch(x, error = function(x) "")
+  x <- tryCatch(x, error = \(x) "")
   unique(x[nzchar(x)])
 }
 
@@ -142,7 +142,7 @@ set_odbcsysini <- function() {
       path <- dirname(odbcListConfig()[["drivers"]])
       Sys.setenv(ODBCSYSINI = path)
     },
-    error = function(err) NULL
+    error = \(err) NULL
   )
 
   invisible()
@@ -162,7 +162,7 @@ random_name <- function(prefix = "") {
 rethrow_database_error <- function(msg, call = trace_back()$call[[1]]) {
   tryCatch(
     res <- parse_database_error(msg),
-    error = function(e) cli::cli_abort("{msg}", call = call)
+    error = \(e) cli::cli_abort("{msg}", call = call)
   )
 
   cli::cli_abort(
@@ -193,7 +193,7 @@ parse_database_error <- function(msg) {
 
   # Remove the square-bracketed context from the database error
   cnd_body <- Reduce(
-    function(p, x) gsub(p, "", x, fixed = TRUE),
+    \(p, x) gsub(p, "", x, fixed = TRUE),
     cnd_context_driver,
     cnd_msg[-1],
     right = TRUE
@@ -510,7 +510,7 @@ driver_dir <- function(driver) {
 }
 
 is_writeable <- function(path) {
-  tryCatch(file.access(path, mode = 2)[[1]] == 0, error = function(e) FALSE)
+  tryCatch(file.access(path, mode = 2)[[1]] == 0, error = \(e) FALSE)
 }
 
 # Given a vector of lines in an ini file, look for a given key pattern.
@@ -627,16 +627,15 @@ decompose_connection_string <- function(string) {
 
   res_pairs <- strsplit(string, ";", fixed = TRUE)[[1]]
   res_key_value <- strsplit(res_pairs, "=", fixed = TRUE)
-  res_key_value <- Filter(function(x) length(x) == 2 && nchar(x[1]),
-                          res_key_value)
-  values <- lapply(res_key_value, FUN = function(x) trimws(x[2]))
+  res_key_value <- Filter(\(x) length(x) == 2 && nchar(x[1]), res_key_value)
+  values <- lapply(res_key_value, FUN = \(x) trimws(x[2]))
   # Remove enclosing quotation marks around value
   # we may have put them there using odbc::quote_value
   values <- lapply(values, FUN = function(x) {
       x <-gsub("(^')(.*)('$)", "\\2", x)
       gsub("(^\")(.*)(\"$)", "\\2", x)
   })
-  nms <- sapply(res_key_value, FUN = function(x) x[1])
+  nms <- sapply(res_key_value, FUN = \(x) x[1])
   names(values) <- trimws(nms)
   return(sanitize_connection_string(values))
 }

--- a/tests/testthat/test-driver-mysql.R
+++ b/tests/testthat/test-driver-mysql.R
@@ -120,6 +120,6 @@ test_that("sproc result retrieval", {
   })
   expect_identical(
     res,
-    data.frame("TestCol" = "abc", stringsAsFactors = FALSE)
+    data.frame("TestCol" = "abc")
   )
 })

--- a/tests/testthat/test-driver-postgres.R
+++ b/tests/testthat/test-driver-postgres.R
@@ -142,8 +142,7 @@ test_that("Writing data.frame with column ordering different than target table",
   values <- data.frame(
     datetime = as.POSIXct(c(14, 15), origin = "2016-01-01", tz = "UTC"),
     name = c("one", "two"),
-    num = 1:2,
-    stringsAsFactors = FALSE
+    num = 1:2
   )
   tbl <- "test_order_write"
   dbCreateTable(con, tbl, values)

--- a/tests/testthat/test-driver-sql-server.R
+++ b/tests/testthat/test-driver-sql-server.R
@@ -156,8 +156,7 @@ test_that("blobs can be retrieved out of order", {
     c1 = 1,
     c2 = "this is varchar max",
     c3 = 11,
-    c4 = "this is text",
-    stringsAsFactors = FALSE
+    c4 = "this is text"
   )
   tbl <- local_table(con, "test_out_of_order_blob", values)
 
@@ -183,8 +182,7 @@ test_that("can bind NA values", {
     c3 = c(1.0, NA_real_),
     c4 = c(TRUE, NA),
     c5 = c(Sys.Date(), NA),
-    c6 = c(Sys.time(), NA),
-    stringsAsFactors = FALSE
+    c6 = c(Sys.time(), NA)
   )
   tbl <- local_table(con, "test_na", values)
 
@@ -480,11 +478,11 @@ test_that("Table-valued parameters", {
   })
 
   df.param <- data.frame(int = 1:10, bigint = 1:10, vrchr = rownames(mtcars)[1:10],
-    vrchr2 = as.character(iris$Species[1:10]), vrchr3 = LETTERS[1:10], stringsAsFactors = FALSE)
+    vrchr2 = as.character(iris$Species[1:10]), vrchr3 = LETTERS[1:10])
   res <- dbGetQuery(con, "{ CALL tvp_test(?, ?, ?) }", params = list(100, df.param, "Lorem ipsum dolor sit amet"))
 
   expected <- cbind(data.frame("p0" = as.integer(100)), df.param,
-    data.frame("p2" = "Lorem ipsum dolor sit amet", stringsAsFactors = FALSE))
+    data.frame("p2" = "Lorem ipsum dolor sit amet"))
   colnames(expected) <- c("p0", "col0", "col1", "col2", "col3", "col4", "p2")
   expected$col1 <- bit64::as.integer64(expected$col1)
   expect_identical(res, expected)


### PR DESCRIPTION
Bumps the minimum R version to 4.2.0 and applies the corresponding cleanups (cf. r-lib/usethis#2220):

* Set `R (>= 4.2.0)` in DESCRIPTION and add a NEWS bullet
* Drop `stringsAsFactors = FALSE` (the default since R 4.0) in R code and tests
* Convert single-line anonymous `function(x)` to `\(x)` throughout `R/`

